### PR TITLE
feat: Add Supabase JS client and initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,8 @@
     </div>
   </div>
   <!-- Your content goes here -->
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="js/supabase-client.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
   <script src="js/main.js"></script>
 </body>

--- a/js/supabase-client.js
+++ b/js/supabase-client.js
@@ -1,0 +1,12 @@
+// js/supabase-client.js
+
+const SUPABASE_URL = 'YOUR_SUPABASE_URL'; // Replace with your actual Supabase URL
+const SUPABASE_ANON_KEY = 'YOUR_SUPABASE_ANON_KEY'; // Replace with your actual Supabase anon key
+
+if (!SUPABASE_URL || SUPABASE_URL === 'YOUR_SUPABASE_URL' || !SUPABASE_ANON_KEY || SUPABASE_ANON_KEY === 'YOUR_SUPABASE_ANON_KEY') {
+  console.error('Supabase URL and Anon Key are required. Please find the file js/supabase-client.js and update them with your project credentials from Supabase settings > API.');
+}
+
+const supabase = Supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+window._supabase = supabase; 
+console.log('Supabase client initialized (or attempted to initialize with placeholder credentials). Ensure credentials are set in js/supabase-client.js.');

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -4,12 +4,14 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Dashboard</title>
-  <script src="../js/dashboard_check.js"></script>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body class="d-flex flex-column justify-content-center align-items-center vh-100">
   <h1>this is your new dashboard page</h1>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="../js/supabase-client.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="../js/dashboard_check.js"></script> 
 </body>
 </html>


### PR DESCRIPTION
- I created js/supabase-client.js with placeholder credentials to initialize the Supabase client and make it globally available.
- I added Supabase JS v2 CDN link to index.html and pages/dashboard.html.
- I linked js/supabase-client.js in index.html and pages/dashboard.html, ensuring correct load order before other custom scripts.
- I adjusted script order in pages/dashboard.html for consistency, moving dashboard_check.js to the end of the body.

This sets up the project to interact with Supabase. The credentials in js/supabase-client.js need to be updated by you.