### PR TITLE
fix: Use specific Supabase JS v2.39.7 UMD build from CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
     </div>
   </div>
   <!-- Your content goes here -->
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.7/dist/umd/supabase.min.js"></script>
   <script>
     if (typeof Supabase === 'undefined') {
       console.error('CRITICAL HTML CHECK: Supabase object NOT defined immediately after CDN script load.');

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -9,7 +9,7 @@
 </head>
 <body class="d-flex flex-column justify-content-center align-items-center vh-100">
   <h1>this is your new dashboard page</h1>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.7/dist/umd/supabase.min.js"></script>
   <script>
     // Similar check can be added here if needed, but primary concern is index.html for signup
     if (typeof Supabase === 'undefined') {


### PR DESCRIPTION
- I changed the Supabase JS CDN link in index.html and pages/dashboard.html from version @2 (latest v2) to a specific version @2.39.7.
- The link now points directly to the UMD build (supabase.min.js), which is suitable for global variable exposure in browsers.

This is an attempt to resolve an issue where the global `Supabase` object was not being defined despite the CDN script being downloaded.