### PR TITLE
feat: Add jQuery CDN and update inline diagnostic script for testing

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,15 +52,29 @@
     </div>
   </div>
   <!-- Your content goes here -->
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.7/dist/umd/supabase.min.js"></script>
   <script>
+    // Inline diagnostic script
+    if (typeof jQuery === 'undefined') {
+      console.error('CRITICAL HTML CHECK: jQuery object NOT defined immediately after CDN script load.');
+      const  msgDiv = document.getElementById('signupMessage') || document.getElementById('loginMessage') || document.body;
+      if(msgDiv && !document.getElementById('jQueryCdnLoadError')) {
+          const errDiv = document.createElement('div');
+          errDiv.id = 'jQueryCdnLoadError'; // Give it an ID to prevent duplicates
+          errDiv.innerHTML = '<strong style="color: red;">Error: jQuery library (CDN) did not load correctly. Check console and network tab.</strong>';
+          msgDiv.prepend(errDiv);
+      }
+    } else {
+      console.log('SUCCESS HTML CHECK: jQuery object IS defined immediately after CDN script load.');
+    }
+
     if (typeof Supabase === 'undefined') {
       console.error('CRITICAL HTML CHECK: Supabase object NOT defined immediately after CDN script load.');
-      // Optionally display an error on the page here too
       const  msgDiv = document.getElementById('signupMessage') || document.getElementById('loginMessage') || document.body;
-      if(msgDiv && !document.getElementById('cdnLoadError')) { // Avoid duplicate messages
+      if(msgDiv && !document.getElementById('supabaseCdnLoadError')) { // Avoid duplicate messages
           const errDiv = document.createElement('div');
-          errDiv.id = 'cdnLoadError';
+          errDiv.id = 'supabaseCdnLoadError'; // Give it an ID
           errDiv.innerHTML = '<strong style="color: red;">Error: Supabase library (CDN) did not load correctly. Check console and network tab.</strong>';
           msgDiv.prepend(errDiv);
       }
@@ -69,7 +83,7 @@
     }
   </script>
   <script src="js/supabase-client.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="js/main.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script> 
+  <script src="js/main.js"></script> 
 </body>
 </html>


### PR DESCRIPTION
- Added jQuery CDN script to index.html before the Supabase CDN script.
- Modified the inline diagnostic script in index.html to check for the global definition of both `jQuery` and `Supabase` objects immediately after their respective CDN scripts should have loaded.
- The script now logs success/error for both and attempts to display on-page errors if either library fails to load.

This is for diagnosing issues with CDN script execution and global object definition.