### PR TITLE
feat: Load Supabase JS library as an ES Module

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,37 +52,7 @@
     </div>
   </div>
   <!-- Your content goes here -->
-  <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.7/dist/umd/supabase.min.js"></script>
-  <script>
-    // Inline diagnostic script
-    if (typeof jQuery === 'undefined') {
-      console.error('CRITICAL HTML CHECK: jQuery object NOT defined immediately after CDN script load.');
-      const  msgDiv = document.getElementById('signupMessage') || document.getElementById('loginMessage') || document.body;
-      if(msgDiv && !document.getElementById('jQueryCdnLoadError')) {
-          const errDiv = document.createElement('div');
-          errDiv.id = 'jQueryCdnLoadError'; // Give it an ID to prevent duplicates
-          errDiv.innerHTML = '<strong style="color: red;">Error: jQuery library (CDN) did not load correctly. Check console and network tab.</strong>';
-          msgDiv.prepend(errDiv);
-      }
-    } else {
-      console.log('SUCCESS HTML CHECK: jQuery object IS defined immediately after CDN script load.');
-    }
-
-    if (typeof Supabase === 'undefined') {
-      console.error('CRITICAL HTML CHECK: Supabase object NOT defined immediately after CDN script load.');
-      const  msgDiv = document.getElementById('signupMessage') || document.getElementById('loginMessage') || document.body;
-      if(msgDiv && !document.getElementById('supabaseCdnLoadError')) { // Avoid duplicate messages
-          const errDiv = document.createElement('div');
-          errDiv.id = 'supabaseCdnLoadError'; // Give it an ID
-          errDiv.innerHTML = '<strong style="color: red;">Error: Supabase library (CDN) did not load correctly. Check console and network tab.</strong>';
-          msgDiv.prepend(errDiv);
-      }
-    } else {
-      console.log('SUCCESS HTML CHECK: Supabase object IS defined immediately after CDN script load.');
-    }
-  </script>
-  <script src="js/supabase-client.js"></script>
+  <script type="module" src="js/supabase-client.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script> 
   <script src="js/main.js"></script> 
 </body>

--- a/js/supabase-client.js
+++ b/js/supabase-client.js
@@ -1,43 +1,36 @@
 // js/supabase-client.js
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'; // Import directly from ESM-friendly CDN
 
-const SUPABASE_URL = 'YOUR_SUPABASE_URL'; // YOU MUST REPLACE THIS
-const SUPABASE_ANON_KEY = 'YOUR_SUPABASE_ANON_KEY'; // YOU MUST REPLACE THIS
+const SUPABASE_URL = 'YOUR_SUPABASE_URL'; // YOU MUST REPLACE THIS (or ensure it's already correct)
+const SUPABASE_ANON_KEY = 'YOUR_SUPABASE_ANON_KEY'; // YOU MUST REPLACE THIS (or ensure it's already correct)
 
-// Enhanced check to be more explicit about placeholder values
+let supabaseInstance = null;
+
 if (SUPABASE_URL === 'YOUR_SUPABASE_URL' || SUPABASE_ANON_KEY === 'YOUR_SUPABASE_ANON_KEY' || !SUPABASE_URL || !SUPABASE_ANON_KEY) {
   console.error(
     'CRITICAL ERROR: Supabase URL and/or Anon Key are still set to placeholder values or are missing in js/supabase-client.js. ' +
     'Please edit this file and replace them with your actual Supabase project credentials from Settings > API.'
   );
-  // Display a more prominent error to the user on the page itself
-  const  msgDiv = document.getElementById('signupMessage') || document.getElementById('loginMessage') || document.body;
-  if(msgDiv) {
+  const msgDiv = document.getElementById('signupMessage') || document.getElementById('loginMessage') || document.body;
+  if (msgDiv) {
     const errDiv = document.createElement('div');
-    errDiv.innerHTML = '<strong style="color: red;">Supabase client is not configured. Please check the console. YOU need to add your API keys to js/supabase-client.js.</strong>';
+    errDiv.innerHTML = '<strong style="color: red;">Supabase client is not configured (missing credentials in js/supabase-client.js).</strong>';
     msgDiv.prepend(errDiv);
+  }
+} else {
+  try {
+    supabaseInstance = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+    console.log('Supabase client initialized via ES Module import.');
+  } catch (e) {
+    console.error('Error during Supabase client initialization (ESM):', e);
+    const msgDiv = document.getElementById('signupMessage') || document.getElementById('loginMessage') || document.body;
+    if (msgDiv) {
+        const errDiv = document.createElement('div');
+        errDiv.innerHTML = '<strong style="color: red;">Error initializing Supabase client. Check console.</strong>';
+        msgDiv.prepend(errDiv);
+    }
   }
 }
 
-try {
-  // The Supabase class should be available globally if the CDN script was loaded first.
-  // Check if Supabase is defined before trying to use it.
-  if (typeof Supabase === 'undefined' || !Supabase || !Supabase.createClient) {
-    console.error('Supabase library (Supabase) is not defined. Check CDN script link and order in HTML.');
-    const  msgDiv = document.getElementById('signupMessage') || document.getElementById('loginMessage') || document.body;
-    if(msgDiv) {
-        const errDiv = document.createElement('div');
-        errDiv.innerHTML = '<strong style="color: red;">Supabase library not loaded. Check HTML script order and console.</strong>';
-        msgDiv.prepend(errDiv);
-    }
-    // To prevent further errors, we can't initialize the client.
-    // Assign a mock or null to window._supabase if needed by other parts of the code to prevent breaking.
-    window._supabase = null; 
-  } else {
-    const supabase = Supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
-    window._supabase = supabase; 
-    console.log('Supabase client initialization attempted. If credentials are placeholders, it will not connect.');
-  }
-} catch (e) {
-  console.error('Error during Supabase client initialization attempt:', e);
-  window._supabase = null; // Ensure it's null if initialization failed
-}
+// Make the client instance globally available for other non-module scripts (like main.js for now)
+window._supabase = supabaseInstance;

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -9,16 +9,7 @@
 </head>
 <body class="d-flex flex-column justify-content-center align-items-center vh-100">
   <h1>this is your new dashboard page</h1>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.7/dist/umd/supabase.min.js"></script>
-  <script>
-    // Similar check can be added here if needed, but primary concern is index.html for signup
-    if (typeof Supabase === 'undefined') {
-      console.error('CRITICAL DASHBOARD HTML CHECK: Supabase object NOT defined after CDN script.');
-    } else {
-      console.log('SUCCESS DASHBOARD HTML CHECK: Supabase object IS defined after CDN script.');
-    }
-  </script>
-  <script src="../js/supabase-client.js"></script>
+  <script type="module" src="../js/supabase-client.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
   <script src="../js/dashboard_check.js"></script> 
 </body>


### PR DESCRIPTION
- Modified index.html and pages/dashboard.html:
  - Removed Supabase UMD CDN script.
  - Removed jQuery CDN and inline diagnostic scripts.
  - Changed the script tag for js/supabase-client.js to type="module".
- Updated js/supabase-client.js:
  - Now imports `createClient` from an ESM-friendly CDN (esm.sh).
  - Initializes Supabase client using the imported function.
  - Continues to use placeholder credentials (you must update).
  - Still exposes the client via window._supabase for other scripts.

This change attempts to resolve issues with the Supabase library's global object not being defined by switching to a module-based loading approach.