### PR TITLE
chore: Add .gitignore and ignore js/supabase-client.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore Supabase client configuration with user's specific keys
+js/supabase-client.js


### PR DESCRIPTION
- I created a .gitignore file at the project root.
- I added js/supabase-client.js to .gitignore.

This is to prevent your Supabase credentials in js/supabase-client.js from being overwritten by placeholder versions in future commits from me. You should commit your credentialed version of js/supabase-client.js to your own repository.