### PR TITLE
feat: Add top bar to dashboard page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -64,3 +64,32 @@ body {
   overflow-y: auto; /* Allow scrolling for main content if it overflows */
   position: relative; /* Added to ensure absolute positioning of children is relative to this */
 }
+
+/* Top Bar Styles */
+.top-bar {
+  display: flex;
+  justify-content: space-between; /* Aligns items to left and right */
+  align-items: center;
+  padding: 10px 20px; /* Adjust padding as needed */
+  background-color: #f8f9fa; /* Same as sidebar background */
+  border-bottom: 1px solid #dee2e6; /* Optional border */
+  height: 60px; /* Adjust height as needed */
+  box-sizing: border-box;
+}
+
+.top-bar .page-title span {
+  font-size: 1.2em; /* Adjust as needed */
+  color: #495057; /* Darker grey for text, adjust as needed */
+  font-weight: 600; /* Semi-bold */
+}
+
+.top-bar .top-bar-icons a {
+  color: #6B7280; /* Default icon color from sidebar elements */
+  font-size: 1.2em; /* Adjust icon size as needed */
+  margin-left: 15px; /* Space between icons */
+  text-decoration: none;
+}
+
+.top-bar .top-bar-icons a:hover {
+  color: #2563EB; /* Hover color, can match active sidebar item or be different */
+}

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -23,11 +23,24 @@
   </div>
 
   <div id="mainContent" class="main-content">
+    <div class="top-bar">
+      <div class="page-title">
+        <span>Dashboard</span>
+      </div>
+      <div class="top-bar-icons">
+        <a href="#"><i class="fas fa-bell"></i></a>
+        <a href="#"><i class="fas fa-question-circle"></i></a>
+        {/* The existing sign-out button will remain separate for now, 
+           though it could be integrated here later if desired. */}
+      </div>
+    </div>
+    
+    {/* Existing Sign-Out Button (still absolutely positioned relative to mainContent) */}
     <div style="position: absolute; top: 10px; right: 10px;">
       <button id="signOutButton" class="btn btn-danger">Sign Out</button>
     </div>
-    
-    <div class="container text-center"> {/* This container might need adjustment based on new layout */}
+
+    <div class="container text-center mt-5"> {/* Added mt-5 to push welcome message down from top-bar and sign-out button */}
       <h1 id="welcomeMessage">this is your new dashboard page</h1>
       {/* Potential future dashboard content here */}
     </div>


### PR DESCRIPTION
- Added HTML structure for a top bar in pages/dashboard.html.
  - Top bar is within the .main-content area.
  - Displays "Dashboard" as the page title on the left.
  - Includes Font Awesome icons for bell (notifications) and question-mark (help/menu) on the right.
- Added CSS rules to css/style.css for the top bar:
  - Styling for layout (flexbox), background color (matching sidebar), padding, height.
  - Styling for page title text and icons.
- Added margin-top to the welcome message container in pages/dashboard.html for better spacing below the new top bar.