### PR TITLE
Refactor: Move sign-out button to sidebar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -29,6 +29,9 @@ body {
   list-style: none;
   padding: 0;
   margin: 0;
+  display: flex; /* Add */
+  flex-direction: column; /* Add */
+  height: calc(100% - 70px); /* Adjust 70px based on logo height and some padding, this is to make space for logo */
 }
 
 .sidebar .nav-menu li a {
@@ -92,4 +95,27 @@ body {
 
 .top-bar .top-bar-icons a:hover {
   color: #2563EB; /* Hover color, can match active sidebar item or be different */
+}
+
+.sidebar .nav-menu li#signOutButtonLi { /* Assuming you add an ID to the LI for easier targeting */
+  margin-top: auto; /* Pushes this item to the bottom */
+  padding: 10px 15px; /* Similar padding to other nav items */
+}
+
+.sidebar .nav-menu li#signOutButtonLi #signOutButton {
+  width: 100%; /* Make button take full width of its container li */
+  display: flex; /* To align icon and text if an icon is added later */
+  align-items: center;
+  justify-content: center; /* Center text */
+  padding: 10px; /* Internal padding for the button */
+  text-decoration: none;
+  font-size: 1em;
+  color: white; /* Text color for contrast with red background */
+  background-color: #dc3545; /* Bootstrap danger red */
+  border: none;
+  border-radius: 0.25rem; /* Optional: match bootstrap button rounding */
+}
+
+.sidebar .nav-menu li#signOutButtonLi #signOutButton:hover {
+  background-color: #c82333; /* Darker red on hover */
 }

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -19,6 +19,7 @@
       <li><a href="#"><i class="fas fa-tasks"></i><span>Tasks</span></a></li>
       <li><a href="#"><i class="fas fa-users"></i><span>Staff</span></a></li>
       <li><a href="#"><i class="fas fa-bell"></i><span>Notifications</span></a></li>
+      <li id="signOutButtonLi"><button id="signOutButton" class="btn btn-danger">Sign Out</button></li>
     </ul>
   </div>
 
@@ -33,9 +34,6 @@
       </div>
     </div>
     
-    <div style="position: absolute; top: 10px; right: 10px;">
-      <button id="signOutButton" class="btn btn-danger">Sign Out</button>
-    </div>
 
     <div class="container text-center mt-5">
       <h1 id="welcomeMessage">this is your new dashboard page</h1>


### PR DESCRIPTION
- Moved the sign-out button from the main content area to the bottom of the sidebar navigation menu.
- Updated HTML structure in `pages/dashboard.html` accordingly.
- Added CSS styles in `css/style.css` to position and style the sign-out button within the sidebar, ensuring it aligns with the overall design and is fixed at the bottom.