### PR TITLE
feat: Add 'Recent Activity' section to dashboard

### DIFF
--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -75,6 +75,75 @@
           </div>
         </div>
       </div>
+      <h3 class="mt-5 mb-3">Recent Activity</h3>
+      <table class="table table-hover align-middle">
+        <tbody>
+          <tr>
+            <td style="width: 50px;">
+              <img src="https://via.placeholder.com/40/007bff/FFFFFF?Text=AS" alt="User" class="img-fluid rounded-circle">
+            </td>
+            <td>Alice Smith</td>
+            <td>Added new property 'Ocean View Condo'</td>
+            <td class="text-muted text-end" style="min-width: 100px;">15m ago</td>
+          </tr>
+          <tr>
+            <td style="width: 50px;">
+              <img src="https://via.placeholder.com/40/6c757d/FFFFFF?Text=BJ" alt="User" class="img-fluid rounded-circle">
+            </td>
+            <td>Bob Johnson</td>
+            <td>Updated staff profile: Mike Lee</td>
+            <td class="text-muted text-end" style="min-width: 100px;">1h ago</td>
+          </tr>
+          <tr>
+            <td style="width: 50px;">
+              <img src="https://via.placeholder.com/40/28a745/FFFFFF?Text=CW" alt="User" class="img-fluid rounded-circle">
+            </td>
+            <td>Carol White</td>
+            <td>Created task: 'Monthly maintenance check'</td>
+            <td class="text-muted text-end" style="min-width: 100px;">3h ago</td>
+          </tr>
+          <tr>
+            <td style="width: 50px;">
+              <img src="https://via.placeholder.com/40/dc3545/FFFFFF?Text=DB" alt="User" class="img-fluid rounded-circle">
+            </td>
+            <td>David Brown</td>
+            <td>Changed property status for 'Downtown Apartment' to 'Rented'</td>
+            <td class="text-muted text-end" style="min-width: 100px;">Yesterday</td>
+          </tr>
+          <tr>
+            <td style="width: 50px;">
+              <img src="https://via.placeholder.com/40/ffc107/000000?Text=EG" alt="User" class="img-fluid rounded-circle">
+            </td>
+            <td>Eve Green</td>
+            <td>Added new staff member: 'Sarah Connor'</td>
+            <td class="text-muted text-end" style="min-width: 100px;">2024-03-10</td>
+          </tr>
+          <tr>
+            <td style="width: 50px;">
+              <img src="https://via.placeholder.com/40/17a2b8/FFFFFF?Text=FB" alt="User" class="img-fluid rounded-circle">
+            </td>
+            <td>Frank Black</td>
+            <td>Completed task: 'Inspect Unit 10B'</td>
+            <td class="text-muted text-end" style="min-width: 100px;">2024-03-09</td>
+          </tr>
+          <tr>
+            <td style="width: 50px;">
+              <img src="https://via.placeholder.com/40/343a40/FFFFFF?Text=GB" alt="User" class="img-fluid rounded-circle">
+            </td>
+            <td>Grace Blue</td>
+            <td>Scheduled property viewing for 'Lakeside Cottage'</td>
+            <td class="text-muted text-end" style="min-width: 100px;">5d ago</td>
+          </tr>
+          <tr>
+            <td style="width: 50px;">
+              <img src="https://via.placeholder.com/40/f8f9fa/000000?Text=HP" alt="User" class="img-fluid rounded-circle">
+            </td>
+            <td>Henry Purple</td>
+            <td>Generated financial report for Q3</td>
+            <td class="text-muted text-end" style="min-width: 100px;">1w ago</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 


### PR DESCRIPTION
- Added a new 'Recent Activity' section below the statistic cards on the dashboard page (`pages/dashboard.html`).
- Section includes a title and a Bootstrap-styled table (`table table-hover align-middle`).
- Populated the table with 8 rows of dummy data, each including:
    - A round placeholder profile image.
    - User name.
    - Performed activity.
    - Time/date of activity.
- Styled using Bootstrap classes; no custom CSS added for this section.