### PR TITLE
feat: Implement responsive design for dashboard

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -120,6 +120,49 @@ body {
   background-color: #c82333; /* Darker red on hover */
 }
 
+/* Responsive Sidebar Styles */
+.sidebar {
+  /* ... existing styles ... */
+  transition: transform 0.3s ease-in-out; /* Smooth transition for sliding */
+}
+
+.top-bar .btn#sidebarToggler { /* Style for the toggler button */
+  color: #495057; /* Match page title color or choose appropriately */
+  font-size: 1.2em; /* Similar to other top-bar icons */
+}
+
+@media (max-width: 991.98px) { /* Bootstrap lg breakpoint - anything below large */
+  .sidebar {
+    transform: translateX(-100%); /* Hide sidebar off-screen to the left */
+    /* Or use: left: -250px; if using left/right positioning */
+    z-index: 1050; /* Ensure sidebar is above other content like overlay if added later */
+  }
+
+  .sidebar.active {
+    transform: translateX(0); /* Show sidebar */
+    /* Or use: left: 0; */
+  }
+
+  .main-content {
+    margin-left: 0; /* Main content takes full width when sidebar is hidden */
+  }
+
+  .sidebar-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5); /* Semi-transparent black */
+    z-index: 1040; /* Below sidebar (1050), above main content */
+    display: none; /* Hidden by default */
+  }
+
+  .sidebar-overlay.active {
+    display: block;
+  }
+}
+
 /* Custom Card Styles */
 .card .card-body .card-title {
   font-size: 18px;

--- a/js/main.js
+++ b/js/main.js
@@ -127,3 +127,23 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   } else { console.error('loginForm not found'); }
 });
+
+// Sidebar Toggler Logic
+document.addEventListener('DOMContentLoaded', function() {
+  const sidebar = document.getElementById('sidebar');
+  const sidebarToggler = document.getElementById('sidebarToggler');
+  const sidebarOverlay = document.querySelector('.sidebar-overlay'); // Get the overlay
+
+  if (sidebar && sidebarToggler && sidebarOverlay) { // Check for overlay too
+    sidebarToggler.addEventListener('click', function() {
+      sidebar.classList.toggle('active');
+      sidebarOverlay.classList.toggle('active'); // Toggle overlay's active class
+    });
+
+    // Optional: Close sidebar if overlay is clicked
+    sidebarOverlay.addEventListener('click', function() {
+      sidebar.classList.remove('active');
+      sidebarOverlay.classList.remove('active');
+    });
+  }
+});

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
 <body>
+  <div class="sidebar-overlay d-lg-none"></div> <!-- Add this line -->
   <div id="sidebar" class="sidebar">
     <div class="logo">
       Property Hub
@@ -25,6 +26,9 @@
 
   <div id="mainContent" class="main-content">
     <div class="top-bar">
+      <button class="btn d-lg-none me-2" type="button" id="sidebarToggler" aria-label="Toggle sidebar">
+        <i class="fas fa-bars"></i>
+      </button>
       <div class="page-title">
         <span>Dashboard</span>
       </div>
@@ -76,10 +80,11 @@
         </div>
       </div>
       <h3 class="mt-5 mb-3">Recent Activity</h3>
-      <table class="table table-hover align-middle">
-        <tbody>
-          <tr>
-            <td style="width: 50px;">
+      <div class="table-responsive">
+        <table class="table table-hover align-middle">
+          <tbody>
+            <tr>
+              <td style="width: 50px;">
               <img src="https://via.placeholder.com/40/007bff/FFFFFF?Text=AS" alt="User" class="img-fluid rounded-circle">
             </td>
             <td>Alice Smith</td>
@@ -142,8 +147,9 @@
             <td>Generated financial report for Q3</td>
             <td class="text-muted text-end" style="min-width: 100px;">1w ago</td>
           </tr>
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
- Made the 'Recent Activity' table responsive using Bootstrap's `.table-responsive` class.
- Implemented a responsive sidebar for screens smaller than 992px (Bootstrap lg breakpoint):
    - Sidebar is hidden by default on small screens and can be toggled open/closed.
    - Added a hamburger icon toggler button to the top bar, visible only on small screens.
    - Main content area adjusts its margin to occupy full width when the sidebar is hidden.
    - Implemented a semi-transparent overlay that appears when the sidebar is open on small screens, and can be clicked to close the sidebar.
- Ensured viewport meta tag is present.
- Relied on Bootstrap's grid system for card responsiveness.