### PR TITLE
feat: Implement initial notifications page structure and client-side …

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -204,3 +204,15 @@ body {
 .row > .col-lg-4:nth-child(3) .card .card-body .card-text {
   text-align: left; /* Ensure left alignment */
 }
+
+/* Custom styles for notifications */
+.list-group-item.notification-read {
+  background-color: #f8f9fa; /* A light grey, similar to Bootstrap's .table-light */
+  opacity: 0.75; /* Slightly faded */
+}
+
+.list-group-item.notification-read h5,
+.list-group-item.notification-read p,
+.list-group-item.notification-read small {
+  /* Optional: could make text color lighter if needed, but opacity might be enough */
+}

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', function() {
+  // Mark as read functionality
+  const markAsReadButtons = document.querySelectorAll('.mark-as-read-btn');
+  markAsReadButtons.forEach(button => {
+    button.addEventListener('click', function(event) {
+      event.stopPropagation(); // Prevent modal from triggering
+      const notificationItem = this.closest('.list-group-item');
+      if (notificationItem) {
+        notificationItem.classList.add('notification-read');
+        // Optional: Disable the 'Mark as read' button, change its text, or hide it
+        // this.disabled = true;
+        // If you want to hide the "Mark as read" button and only keep "Delete"
+        // this.style.display = 'none'; 
+      }
+    });
+  });
+
+  // Delete functionality
+  const deleteButtons = document.querySelectorAll('.delete-notification-btn');
+  deleteButtons.forEach(button => {
+    button.addEventListener('click', function(event) {
+      event.stopPropagation(); // Prevent modal from triggering
+      const notificationItem = this.closest('.list-group-item');
+      if (notificationItem) {
+        notificationItem.remove(); // Removes the notification item from the DOM
+      }
+    });
+  });
+});

--- a/pages/notifications.html
+++ b/pages/notifications.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Notifications</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body>
+  <div class="sidebar-overlay d-lg-none"></div> <!-- Add this line -->
+  <div id="sidebar" class="sidebar">
+    <div class="logo">
+      Property Hub
+    </div>
+    <ul class="nav-menu">
+      <li><a href="dashboard.html"><i class="fas fa-tachometer-alt"></i><span>Dashboard</span></a></li>
+      <li><a href="#"><i class="fas fa-building"></i><span>Properties</span></a></li>
+      <li><a href="#"><i class="fas fa-tasks"></i><span>Tasks</span></a></li>
+      <li><a href="#"><i class="fas fa-users"></i><span>Staff</span></a></li>
+      <li><a href="#" class="active"><i class="fas fa-bell"></i><span>Notifications</span></a></li>
+      <li id="signOutButtonLi"><button id="signOutButton" class="btn btn-danger">Sign Out</button></li>
+    </ul>
+  </div>
+
+  <div id="mainContent" class="main-content">
+    <div class="top-bar">
+      <button class="btn d-lg-none me-2" type="button" id="sidebarToggler" aria-label="Toggle sidebar">
+        <i class="fas fa-bars"></i>
+      </button>
+      <div class="page-title">
+        <span>Notifications</span>
+      </div>
+      <div class="top-bar-icons">
+        <a href="#"><i class="fas fa-bell"></i></a>
+        <a href="#"><i class="fas fa-question-circle"></i></a>
+      </div>
+    </div>
+    
+
+    <div class="container mt-5">
+      <div class="row mb-3">
+        <div class="col text-end">
+          <button class="btn btn-outline-primary" id="markAllReadBtn">Mark all as read</button>
+        </div>
+      </div>
+      <ul class="list-group" id="notificationList">
+        <li class="list-group-item list-group-item-action" data-bs-toggle="modal" data-bs-target="#notificationModalTemplate">
+          <div class="d-flex w-100 justify-content-between">
+            <h5 class="mb-1">New Property Alert</h5>
+            <small class="text-muted">15m ago</small>
+          </div>
+          <p class="mb-1">A new property matching your criteria in 'Downtown Area' has been listed.</p>
+          <div class="mt-2">
+            <button type="button" class="btn btn-sm btn-outline-secondary me-2 mark-as-read-btn">Mark as read</button>
+            <button type="button" class="btn btn-sm btn-outline-danger delete-notification-btn">Delete</button>
+          </div>
+        </li>
+        <li class="list-group-item list-group-item-action" data-bs-toggle="modal" data-bs-target="#notificationModalTemplate">
+          <div class="d-flex w-100 justify-content-between">
+            <h5 class="mb-1">Task Reminder: Inspection Due</h5>
+            <small class="text-muted">1h ago</small>
+          </div>
+          <p class="mb-1">Don't forget the quarterly inspection for 'Villa Heights' is due tomorrow.</p>
+          <div class="mt-2">
+            <button type="button" class="btn btn-sm btn-outline-secondary me-2 mark-as-read-btn">Mark as read</button>
+            <button type="button" class="btn btn-sm btn-outline-danger delete-notification-btn">Delete</button>
+          </div>
+        </li>
+        <li class="list-group-item list-group-item-action" data-bs-toggle="modal" data-bs-target="#notificationModalTemplate">
+          <div class="d-flex w-100 justify-content-between">
+            <h5 class="mb-1">Staff Update: Welcome aboard!</h5>
+            <small class="text-muted">Yesterday</small>
+          </div>
+          <p class="mb-1">John B. has joined the team as a Property Manager.</p>
+          <div class="mt-2">
+            <button type="button" class="btn btn-sm btn-outline-secondary me-2 mark-as-read-btn">Mark as read</button>
+            <button type="button" class="btn btn-sm btn-outline-danger delete-notification-btn">Delete</button>
+          </div>
+        </li>
+        <li class="list-group-item list-group-item-action" data-bs-toggle="modal" data-bs-target="#notificationModalTemplate">
+          <div class="d-flex w-100 justify-content-between">
+            <h5 class="mb-1">Maintenance Request</h5>
+            <small class="text-muted">2 days ago</small>
+          </div>
+          <p class="mb-1">Tenant in Unit 5B reported a leaky faucet. Please assign a plumber.</p>
+          <div class="mt-2">
+            <button type="button" class="btn btn-sm btn-outline-secondary me-2 mark-as-read-btn">Mark as read</button>
+            <button type="button" class="btn btn-sm btn-outline-danger delete-notification-btn">Delete</button>
+          </div>
+        </li>
+        <li class="list-group-item list-group-item-action" data-bs-toggle="modal" data-bs-target="#notificationModalTemplate">
+          <div class="d-flex w-100 justify-content-between">
+            <h5 class="mb-1">System Update Scheduled</h5>
+            <small class="text-muted">Next Tuesday at 10 PM</small>
+          </div>
+          <p class="mb-1">The system will be down for scheduled maintenance for approximately 30 minutes.</p>
+          <div class="mt-2">
+            <button type="button" class="btn btn-sm btn-outline-secondary me-2 mark-as-read-btn">Mark as read</button>
+            <button type="button" class="btn btn-sm btn-outline-danger delete-notification-btn">Delete</button>
+          </div>
+        </li>
+      </ul>
+
+      <!-- Generic Modal Structure (to be detailed in Phase 2) -->
+      <div class="modal fade" id="notificationModalTemplate" tabindex="-1" aria-labelledby="notificationModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="notificationModalLabel">Notification Details</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+              This is where the full notification content will appear.
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="../js/supabase-client.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
+  <script type="module" src="../js/dashboard_check.js"></script> 
+  <script src="../js/main.js"></script> <!-- This is the new line -->
+  <script src="../js/notifications.js"></script> <!-- This is the new line -->
+</body>
+</html>


### PR DESCRIPTION
…interactivity

- Created `pages/notifications.html` based on the dashboard layout, including sidebar and top bar.
- Added a 'Mark all as read' button to the notifications page.
- Implemented a list group to display notifications, populating it with 5 dummy items.
- Each notification item includes:
    - Dummy title, summary, and time.
    - Buttons for 'Mark as read' and 'Delete'.
    - Functionality to trigger a (currently static) Bootstrap modal for details.
- Created `js/notifications.js` and linked it to `notifications.html`.
- Implemented client-side JavaScript for:
    - 'Mark as read': Changes the visual appearance of the notification item.
    - 'Delete': Removes the notification item from the DOM.
- Added basic CSS in `style.css` for the 'read' state of notifications.
- The sidebar 'Notifications' link on the new page is set to active. The dashboard link points to dashboard.html.