### PR TITLE
fix: Correct sidebar navigation links for Notifications page

### DIFF
--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -19,7 +19,7 @@
       <li><a href="#"><i class="fas fa-building"></i><span>Properties</span></a></li>
       <li><a href="#"><i class="fas fa-tasks"></i><span>Tasks</span></a></li>
       <li><a href="#"><i class="fas fa-users"></i><span>Staff</span></a></li>
-      <li><a href="#"><i class="fas fa-bell"></i><span>Notifications</span></a></li>
+      <li><a href="notifications.html"><i class="fas fa-bell"></i><span>Notifications</span></a></li>
       <li id="signOutButtonLi"><button id="signOutButton" class="btn btn-danger">Sign Out</button></li>
     </ul>
   </div>


### PR DESCRIPTION
- Updated the 'Notifications' link in the sidebar on `pages/dashboard.html` to correctly point to `pages/notifications.html`.
- Verified that the 'Dashboard' link on `pages/notifications.html` correctly points back to `pages/dashboard.html`.