### PR TITLE
feat: Implement enhanced notifications page with active/inactive sect…

### DIFF
--- a/js/notifications.js
+++ b/js/notifications.js
@@ -1,29 +1,119 @@
 document.addEventListener('DOMContentLoaded', function() {
-  // Mark as read functionality
-  const markAsReadButtons = document.querySelectorAll('.mark-as-read-btn');
-  markAsReadButtons.forEach(button => {
-    button.addEventListener('click', function(event) {
-      event.stopPropagation(); // Prevent modal from triggering
-      const notificationItem = this.closest('.list-group-item');
-      if (notificationItem) {
-        notificationItem.classList.add('notification-read');
-        // Optional: Disable the 'Mark as read' button, change its text, or hide it
-        // this.disabled = true;
-        // If you want to hide the "Mark as read" button and only keep "Delete"
-        // this.style.display = 'none'; 
-      }
-    });
-  });
+  const activeNotificationsList = document.getElementById('activeNotificationsList');
+  const inactiveNotificationsList = document.getElementById('inactiveNotificationsList');
+  const activeNotificationsPlaceholder = document.getElementById('activeNotificationsPlaceholder');
+  const inactiveNotificationsPlaceholder = document.getElementById('inactiveNotificationsPlaceholder');
+  const markAllReadBtn = document.getElementById('markAllReadBtn'); // Added this line
 
-  // Delete functionality
-  const deleteButtons = document.querySelectorAll('.delete-notification-btn');
-  deleteButtons.forEach(button => {
-    button.addEventListener('click', function(event) {
-      event.stopPropagation(); // Prevent modal from triggering
-      const notificationItem = this.closest('.list-group-item');
-      if (notificationItem) {
-        notificationItem.remove(); // Removes the notification item from the DOM
+  function updateEmptyStatePlaceholders() {
+    if (!activeNotificationsList || !activeNotificationsPlaceholder || !inactiveNotificationsList || !inactiveNotificationsPlaceholder) {
+        // If any element is missing (e.g. due to dynamic page changes not anticipated), exit to prevent errors.
+        // This might happen if the script is loaded on a page without these elements.
+        console.warn("Notification list or placeholder elements not found. Skipping empty state update.");
+        return; 
+    }
+
+    // Check Active Notifications
+    if (activeNotificationsList.children.length === 0) {
+      activeNotificationsList.style.display = 'none';
+      activeNotificationsPlaceholder.style.display = 'block'; 
+    } else {
+      activeNotificationsList.style.display = 'block'; 
+      activeNotificationsPlaceholder.style.display = 'none';
+    }
+
+    // Check Inactive Notifications
+    if (inactiveNotificationsList.children.length === 0) {
+      inactiveNotificationsList.style.display = 'none';
+      inactiveNotificationsPlaceholder.style.display = 'block';
+    } else {
+      inactiveNotificationsList.style.display = 'block';
+      inactiveNotificationsPlaceholder.style.display = 'none';
+    }
+  }
+
+  function handleNotificationAction(event) {
+    const targetButton = event.target;
+    const notificationItem = targetButton.closest('.list-group-item');
+
+    if (!notificationItem) return;
+
+    let itemMoved = false;
+
+    // Handle "Mark as read" / "Mark as unread" clicks
+    if (targetButton.classList.contains('mark-as-read-btn')) {
+      event.stopPropagation(); 
+      notificationItem.classList.add('notification-read');
+      targetButton.textContent = 'Mark as unread';
+      targetButton.classList.remove('mark-as-read-btn', 'btn-outline-secondary');
+      targetButton.classList.add('mark-as-unread-btn', 'btn-secondary');
+      
+      inactiveNotificationsList.appendChild(notificationItem); 
+      itemMoved = true;
+
+    } else if (targetButton.classList.contains('mark-as-unread-btn')) {
+      event.stopPropagation(); 
+      notificationItem.classList.remove('notification-read');
+      targetButton.textContent = 'Mark as read';
+      targetButton.classList.remove('mark-as-unread-btn', 'btn-secondary');
+      targetButton.classList.add('mark-as-read-btn', 'btn-outline-secondary');
+
+      activeNotificationsList.appendChild(notificationItem); 
+      itemMoved = true;
+    }
+
+    // Handle "Delete" clicks
+    if (targetButton.classList.contains('delete-notification-btn')) {
+      event.stopPropagation(); 
+      notificationItem.remove();
+      itemMoved = true; // Treat deletion as a list change
+    }
+
+    if (itemMoved) {
+      updateEmptyStatePlaceholders();
+    }
+  }
+
+  if (activeNotificationsList) {
+    activeNotificationsList.addEventListener('click', handleNotificationAction);
+  }
+  if (inactiveNotificationsList) {
+    inactiveNotificationsList.addEventListener('click', handleNotificationAction);
+  }
+
+  // Initial empty state check
+  updateEmptyStatePlaceholders(); 
+
+  if (markAllReadBtn) {
+    markAllReadBtn.addEventListener('click', function() {
+      const itemsToMarkRead = Array.from(activeNotificationsList.querySelectorAll('.list-group-item'));
+      
+      if (itemsToMarkRead.length === 0) {
+        // Optionally, provide feedback if there's nothing to mark as read
+        // console.log("No active notifications to mark as read.");
+        return; 
       }
+
+      itemsToMarkRead.forEach(item => {
+        // Add .notification-read class to the list item
+        item.classList.add('notification-read');
+        
+        // Find the "Mark as read" button within this item
+        const button = item.querySelector('.mark-as-read-btn'); // Only target unread buttons
+        if (button) {
+          button.textContent = 'Mark as unread';
+          button.classList.remove('mark-as-read-btn', 'btn-outline-secondary');
+          button.classList.add('mark-as-unread-btn', 'btn-secondary');
+        }
+        
+        // Move the item to the inactive list
+        inactiveNotificationsList.appendChild(item);
+      });
+      
+      updateEmptyStatePlaceholders();
     });
-  });
+  }
+
+  // Initial empty state check (should be the last thing before DOMContentLoaded closes)
+  updateEmptyStatePlaceholders(); 
 });

--- a/pages/notifications.html
+++ b/pages/notifications.html
@@ -40,12 +40,16 @@
     
 
     <div class="container mt-5">
-      <div class="row mb-3">
-        <div class="col text-end">
-          <button class="btn btn-outline-primary" id="markAllReadBtn">Mark all as read</button>
-        </div>
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h3 class="mb-0">Notifications</h3>
+        <button class="btn btn-outline-primary" id="markAllReadBtn">Mark all as read</button>
       </div>
-      <ul class="list-group" id="notificationList">
+
+      <h4 class="mt-4">Active Notifications</h4> <!-- Added mt-4 for spacing -->
+      <div id="activeNotificationsPlaceholder" class="text-muted p-3" style="display: none;"> <!-- Added padding and initial display none -->
+        You're all caught up! No new notifications here.
+      </div>
+      <ul class="list-group mb-4" id="activeNotificationsList">
         <li class="list-group-item list-group-item-action" data-bs-toggle="modal" data-bs-target="#notificationModalTemplate">
           <div class="d-flex w-100 justify-content-between">
             <h5 class="mb-1">New Property Alert</h5>
@@ -103,6 +107,13 @@
         </li>
       </ul>
 
+      <h4 class="mt-4">Inactive Notifications</h4> <!-- Added mt-4 for spacing -->
+      <div id="inactiveNotificationsPlaceholder" class="text-muted p-3" style="display: none;"> <!-- Added padding and initial display none -->
+        No inactive notifications.
+      </div>
+      <ul class="list-group" id="inactiveNotificationsList">
+        <!-- Read notifications will move here -->
+      </ul>
       <!-- Generic Modal Structure (to be detailed in Phase 2) -->
       <div class="modal fade" id="notificationModalTemplate" tabindex="-1" aria-labelledby="notificationModalLabel" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered">


### PR DESCRIPTION
…ions

This commit introduces a full-featured notifications page (`pages/notifications.html`) and enhances its functionality based on your feedback.

Key changes include:

1.  **New File:**
    -   Created `pages/notifications.html`, styled consistently with `pages/dashboard.html`.

2.  **HTML Structure (`pages/notifications.html`):**
    -   Page divided into "Active Notifications" and "Inactive Notifications" sections, each with a list area and placeholders for empty states.
    -   "Mark all as read" button positioned at the top.
    -   5 dummy notifications are initially placed in the "Active" list.
    -   Each notification item has "Mark as read"/"Mark as unread" and "Delete" buttons, and triggers a generic modal on click (modal content is static for now).

3.  **JavaScript Logic (`js/notifications.js`):**
    -   **Button Text Toggle:** "Mark as read" button text changes to "Mark as unread" and vice-versa, with corresponding CSS class changes on the button.
    -   **Notification Movement:**
        -   Marking as read moves an item from Active to Inactive list.
        -   Marking as unread moves an item from Inactive to Active list.
    -   **Empty State Handling:** JavaScript dynamically shows/hides messages like "You're all caught up!" or "No inactive notifications." based on list content.
    -   **"Mark all as read" Button:** Functionality implemented to mark all active notifications as read and move them to the inactive list.
    -   **Delete Functionality:** Allows removing notifications, updating empty state messages.
    -   Event delegation is used for robust event handling on notification items.

4.  **CSS (`css/style.css`):**
    -   Added `.notification-read` class to style notifications that have been marked as read (e.g., faded background/opacity).

5.  **Navigation:**
    -   The "Notifications" link in the sidebar of `pages/dashboard.html` now correctly points to `pages/notifications.html`.
    -   Links within `pages/notifications.html` (e.g., to Dashboard) are correctly set.