### PR TITLE
fix: Link top bar bell icon to notifications page

### DIFF
--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -33,7 +33,7 @@
         <span>Dashboard</span>
       </div>
       <div class="top-bar-icons">
-        <a href="#"><i class="fas fa-bell"></i></a>
+        <a href="notifications.html"><i class="fas fa-bell"></i></a>
         <a href="#"><i class="fas fa-question-circle"></i></a>
       </div>
     </div>

--- a/pages/notifications.html
+++ b/pages/notifications.html
@@ -33,7 +33,7 @@
         <span>Notifications</span>
       </div>
       <div class="top-bar-icons">
-        <a href="#"><i class="fas fa-bell"></i></a>
+        <a href="notifications.html"><i class="fas fa-bell"></i></a>
         <a href="#"><i class="fas fa-question-circle"></i></a>
       </div>
     </div>


### PR DESCRIPTION
- Updated the bell icon in the top bar to link to `notifications.html` on both `pages/dashboard.html` and `pages/notifications.html`.