### PR TITLE
feat: Add Company Settings section and fix icon on Account page

### DIFF
--- a/pages/account.html
+++ b/pages/account.html
@@ -34,7 +34,7 @@
       </div>
       <div class="top-bar-icons">
         <a href="notifications.html"><i class="fas fa-bell"></i></a>
-        <a href="#"><i class="fas fa-question-circle"></i></a>
+        <a href="account.html"><i class="fas fa-user-cog"></i></a>
       </div>
     </div>
     
@@ -95,6 +95,81 @@
             </div>
             <button type="submit" class="btn btn-success">Change Password</button> 
             <!-- type="submit" is more appropriate for a form, though no action is wired up -->
+          </form>
+        </div>
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-header">
+          <h5 class="mb-0">Company Settings</h5>
+        </div>
+        <div class="card-body">
+          <form>
+            <div class="row">
+              <div class="col-md-12 mb-3">
+                <label class="form-label">Company Logo</label>
+                <div class="mb-2">
+                  <!-- Placeholder for current logo -->
+                  <img src="https://via.placeholder.com/150x50?text=Company+Logo" class="img-thumbnail" alt="Current Company Logo" id="currentCompanyLogo" style="max-height: 60px;">
+                  <!-- <i class="fas fa-building fa-3x text-secondary d-block mb-2"></i> Alternative icon placeholder -->
+                </div>
+                <input class="form-control form-control-sm" type="file" id="companyLogoUpload">
+                <small class="form-text text-muted">Upload a new logo (e.g., PNG, JPG up to 2MB). Display only, no actual upload.</small>
+              </div>
+            </div>
+
+            <div class="row">
+              <div class="col-md-6 mb-3">
+                <label for="companyName" class="form-label">Company Name</label>
+                <input type="text" class="form-control" id="companyName" value="Example Corp. (Dummy)">
+              </div>
+              <div class="col-md-6 mb-3">
+                <label for="companyPhone" class="form-label">Company Phone</label>
+                <input type="tel" class="form-control" id="companyPhone" value="+1 555 123 4567 (Dummy)">
+              </div>
+            </div>
+
+            <div class="mb-3">
+              <label for="companyEmail" class="form-label">Company Contact Email</label>
+              <input type="email" class="form-control" id="companyEmail" value="contact@examplecorp.com (Dummy)">
+            </div>
+
+            <div class="mb-3">
+              <label for="companyAddressStreet" class="form-label">Street Address</label>
+              <textarea class="form-control" id="companyAddressStreet" rows="2">123 Main Street (Dummy)</textarea>
+            </div>
+
+            <div class="row">
+              <div class="col-md-4 mb-3">
+                <label for="companyAddressCity" class="form-label">City</label>
+                <input type="text" class="form-control" id="companyAddressCity" value="Anytown (Dummy)">
+              </div>
+              <div class="col-md-3 mb-3">
+                <label for="companyAddressState" class="form-label">State/Province</label>
+                <input type="text" class="form-control" id="companyAddressState" value="CA (Dummy)">
+              </div>
+              <div class="col-md-2 mb-3">
+                <label for="companyAddressZip" class="form-label">Zip/Postal Code</label>
+                <input type="text" class="form-control" id="companyAddressZip" value="90210 (Dummy)">
+              </div>
+              <div class="col-md-3 mb-3">
+                <label for="companyAddressCountry" class="form-label">Country</label>
+                <input type="text" class="form-control" id="companyAddressCountry" value="USA (Dummy)">
+              </div>
+            </div>
+
+            <div class="row">
+              <div class="col-md-6 mb-3">
+                <label for="companyWebsite" class="form-label">Company Website (Optional)</label>
+                <input type="url" class="form-control" id="companyWebsite" value="https://www.examplecorp.com (Dummy)">
+              </div>
+              <div class="col-md-6 mb-3">
+                <label for="companyTaxId" class="form-label">Tax ID / VAT Number (Optional)</label>
+                <input type="text" class="form-control" id="companyTaxId" value="VAT123456789 (Dummy)">
+              </div>
+            </div>
+            
+            <button type="submit" class="btn btn-primary">Save Company Settings</button>
           </form>
         </div>
       </div>


### PR DESCRIPTION
- Updated the top bar icon on `pages/account.html` to `fa-user-cog` and ensured it links to `account.html`.
- Added a new "Company Settings" card to `pages/account.html`. This section includes UI elements for:
    - Company logo (placeholder and file input).
    - Company Name, Phone, Contact Email.
    - Company Address (Street, City, State, Zip, Country).
    - Optional fields for Company Website and Tax ID.
- All new fields are pre-filled with dummy data and use Bootstrap styling.
- The new section is placed between "Change Password" and "Notification Preferences".