### PR TITLE
refactor: Replace company logo placeholder with Font Awesome icon

### DIFF
--- a/pages/account.html
+++ b/pages/account.html
@@ -108,10 +108,9 @@
             <div class="row">
               <div class="col-md-12 mb-3">
                 <label class="form-label">Company Logo</label>
-                <div class="mb-2">
+                <div class="mb-2 text-center"> <!-- Added text-center for better icon alignment if it's block/inline-block -->
                   <!-- Placeholder for current logo -->
-                  <img src="https://via.placeholder.com/150x50?text=Company+Logo" class="img-thumbnail" alt="Current Company Logo" id="currentCompanyLogo" style="max-height: 60px;">
-                  <!-- <i class="fas fa-building fa-3x text-secondary d-block mb-2"></i> Alternative icon placeholder -->
+                  <i class="fas fa-palette fa-4x text-secondary"></i>
                 </div>
                 <input class="form-control form-control-sm" type="file" id="companyLogoUpload">
                 <small class="form-text text-muted">Upload a new logo (e.g., PNG, JPG up to 2MB). Display only, no actual upload.</small>


### PR DESCRIPTION
- In `pages/account.html`, within the "Company Settings" section, I replaced the `<img>` tag used as a company logo placeholder with a Font Awesome icon (`fas fa-palette fa-4x text-secondary`).
- I also centered the icon within its container.