### PR TITLE
feat: Create properties page with Bootstrap 5

### DIFF
--- a/assets/images/highland.svg
+++ b/assets/images/highland.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="200" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#D2B48C"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="30" fill="#000000">Highland Park</text>
+</svg>

--- a/assets/images/metropolitan.svg
+++ b/assets/images/metropolitan.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="200" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#6A5ACD"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="30" fill="#FFFFFF">Metropolitan</text>
+</svg>

--- a/assets/images/ocean-view.svg
+++ b/assets/images/ocean-view.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="200" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#00CED1"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="30" fill="#FFFFFF">Ocean View</text>
+</svg>

--- a/assets/images/pine-valley.svg
+++ b/assets/images/pine-valley.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="200" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#2E8B57"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="30" fill="#FFFFFF">Pine Valley</text>
+</svg>

--- a/assets/images/riverside.svg
+++ b/assets/images/riverside.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="200" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#4682B4"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="30" fill="#FFFFFF">Riverside Towers</text>
+</svg>

--- a/assets/images/sunset.svg
+++ b/assets/images/sunset.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="200" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#FFA07A"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="30" fill="#FFFFFF">Sunset Apt</text>
+</svg>

--- a/css/style.css
+++ b/css/style.css
@@ -216,3 +216,9 @@ body {
 .list-group-item.notification-read small {
   /* Optional: could make text color lighter if needed, but opacity might be enough */
 }
+
+.property-card-img {
+  height: 200px;
+  object-fit: cover;
+  width: 100%; /* Ensure it spans the card width */
+}

--- a/pages/account.html
+++ b/pages/account.html
@@ -16,7 +16,7 @@
     </div>
     <ul class="nav-menu">
       <li><a href="dashboard.html"><i class="fas fa-tachometer-alt"></i><span>Dashboard</span></a></li>
-      <li><a href="#"><i class="fas fa-building"></i><span>Properties</span></a></li>
+      <li><a href="properties.html"><i class="fas fa-building"></i><span>Properties</span></a></li>
       <li><a href="#"><i class="fas fa-tasks"></i><span>Tasks</span></a></li>
       <li><a href="#"><i class="fas fa-users"></i><span>Staff</span></a></li>
       <li><a href="notifications.html"><i class="fas fa-bell"></i><span>Notifications</span></a></li>

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -16,7 +16,7 @@
     </div>
     <ul class="nav-menu">
       <li><a href="#" class="active"><i class="fas fa-tachometer-alt"></i><span>Dashboard</span></a></li>
-      <li><a href="#"><i class="fas fa-building"></i><span>Properties</span></a></li>
+      <li><a href="properties.html"><i class="fas fa-building"></i><span>Properties</span></a></li>
       <li><a href="#"><i class="fas fa-tasks"></i><span>Tasks</span></a></li>
       <li><a href="#"><i class="fas fa-users"></i><span>Staff</span></a></li>
       <li><a href="notifications.html"><i class="fas fa-bell"></i><span>Notifications</span></a></li>

--- a/pages/notifications.html
+++ b/pages/notifications.html
@@ -16,7 +16,7 @@
     </div>
     <ul class="nav-menu">
       <li><a href="dashboard.html"><i class="fas fa-tachometer-alt"></i><span>Dashboard</span></a></li>
-      <li><a href="#"><i class="fas fa-building"></i><span>Properties</span></a></li>
+      <li><a href="properties.html"><i class="fas fa-building"></i><span>Properties</span></a></li>
       <li><a href="#"><i class="fas fa-tasks"></i><span>Tasks</span></a></li>
       <li><a href="#"><i class="fas fa-users"></i><span>Staff</span></a></li>
       <li><a href="#" class="active"><i class="fas fa-bell"></i><span>Notifications</span></a></li>

--- a/pages/properties.html
+++ b/pages/properties.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Properties</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body>
+  <div class="sidebar-overlay d-lg-none"></div> <!-- Add this line -->
+  <div id="sidebar" class="sidebar">
+    <div class="logo">
+      Property Hub
+    </div>
+    <ul class="nav-menu">
+      <li><a href="dashboard.html"><i class="fas fa-tachometer-alt"></i><span>Dashboard</span></a></li>
+      <li><a href="properties.html" class="active"><i class="fas fa-building"></i><span>Properties</span></a></li>
+      <li><a href="#"><i class="fas fa-tasks"></i><span>Tasks</span></a></li>
+      <li><a href="#"><i class="fas fa-users"></i><span>Staff</span></a></li>
+      <li><a href="notifications.html"><i class="fas fa-bell"></i><span>Notifications</span></a></li>
+      <li id="signOutButtonLi"><button id="signOutButton" class="btn btn-danger">Sign Out</button></li>
+    </ul>
+  </div>
+
+  <div id="mainContent" class="main-content">
+    <div class="top-bar">
+      <button class="btn d-lg-none me-2" type="button" id="sidebarToggler" aria-label="Toggle sidebar">
+        <i class="fas fa-bars"></i>
+      </button>
+      <div class="page-title">
+        <span>Properties</span>
+      </div>
+      <div class="top-bar-icons">
+        <a href="notifications.html"><i class="fas fa-bell"></i></a>
+        <a href="account.html"><i class="fas fa-user-cog"></i></a>
+      </div>
+    </div>
+    
+    <div class="container mt-5 p-4">
+      <!-- Search and Action Buttons -->
+      <div class="d-flex justify-content-between align-items-center mb-4">
+        <input type="text" placeholder="Search properties..." class="form-control w-33">
+        <div class="d-flex align-items-center">
+          <button class="btn btn-outline-secondary me-2">Filter</button>
+          <button class="btn btn-outline-secondary me-2">☰</button>
+          <button class="btn btn-primary">+ Add Property</button>
+        </div>
+      </div>
+    
+      <!-- Properties Grid -->
+      <div class="row g-4">
+        <!-- Property Card 1 -->
+        <div class="col-12 col-sm-6 col-lg-4">
+          <div class="card h-100 shadow-sm">
+            <img src="../assets/images/sunset.svg" alt="Sunset Apartments" class="card-img-top property-card-img">
+            <div class="card-body d-flex flex-column">
+              <h3 class="card-title">Sunset Apartments</h3>
+              <p class="card-text text-muted small">123 Maple Street, Seattle, WA</p>
+              <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
+                <span class="badge bg-danger rounded-pill px-3 py-1">3 Tasks</span>
+                <a href="#" class="text-primary small">View Details</a>
+              </div>
+            </div>
+          </div>
+        </div>
+    
+        <!-- Property Card 2 -->
+        <div class="col-12 col-sm-6 col-lg-4">
+          <div class="card h-100 shadow-sm">
+            <img src="../assets/images/pine-valley.svg" alt="Pine Valley Complex" class="card-img-top property-card-img">
+            <div class="card-body d-flex flex-column">
+              <h3 class="card-title">Pine Valley Complex</h3>
+              <p class="card-text text-muted small">456 Oak Avenue, Portland, OR</p>
+              <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
+                <span class="badge bg-warning text-dark rounded-pill px-3 py-1">5 Tasks</span>
+                <a href="#" class="text-primary small">View Details</a>
+              </div>
+            </div>
+          </div>
+        </div>
+    
+        <!-- Property Card 3 -->
+        <div class="col-12 col-sm-6 col-lg-4">
+          <div class="card h-100 shadow-sm">
+            <img src="../assets/images/riverside.svg" alt="Riverside Towers" class="card-img-top property-card-img">
+            <div class="card-body d-flex flex-column">
+              <h3 class="card-title">Riverside Towers</h3>
+              <p class="card-text text-muted small">789 River Road, Vancouver, BC</p>
+              <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
+                <span class="badge bg-success rounded-pill px-3 py-1">No Active Tasks</span>
+                <a href="#" class="text-primary small">View Details</a>
+              </div>
+            </div>
+          </div>
+        </div>
+    
+        <!-- Property Card 4 -->
+        <div class="col-12 col-sm-6 col-lg-4">
+          <div class="card h-100 shadow-sm">
+            <img src="../assets/images/highland.svg" alt="Highland Park Residences" class="card-img-top property-card-img">
+            <div class="card-body d-flex flex-column">
+              <h3 class="card-title">Highland Park Residences</h3>
+              <p class="card-text text-muted small">321 Hill Street, San Francisco, CA</p>
+              <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
+                <span class="badge bg-danger rounded-pill px-3 py-1">2 Tasks</span>
+                <a href="#" class="text-primary small">View Details</a>
+              </div>
+            </div>
+          </div>
+        </div>
+    
+        <!-- Property Card 5 -->
+        <div class="col-12 col-sm-6 col-lg-4">
+          <div class="card h-100 shadow-sm">
+            <img src="../assets/images/ocean-view.svg" alt="Ocean View Condos" class="card-img-top property-card-img">
+            <div class="card-body d-flex flex-column">
+              <h3 class="card-title">Ocean View Condos</h3>
+              <p class="card-text text-muted small">654 Beach Blvd, San Diego, CA</p>
+              <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
+                <span class="badge bg-success rounded-pill px-3 py-1">No Active Tasks</span>
+                <a href="#" class="text-primary small">View Details</a>
+              </div>
+            </div>
+          </div>
+        </div>
+    
+        <!-- Property Card 6 -->
+        <div class="col-12 col-sm-6 col-lg-4">
+          <div class="card h-100 shadow-sm">
+            <img src="../assets/images/metropolitan.svg" alt="Metropolitan Heights" class="card-img-top property-card-img">
+            <div class="card-body d-flex flex-column">
+              <h3 class="card-title">Metropolitan Heights</h3>
+              <p class="card-text text-muted small">987 City Center, Los Angeles, CA</p>
+              <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
+                <span class="badge bg-warning text-dark rounded-pill px-3 py-1">4 Tasks</span>
+                <a href="#" class="text-primary small">View Details</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    
+      <!-- Pagination -->
+      <div class="d-flex justify-content-between align-items-center mt-5">
+        <p class="text-muted small mb-0">Showing 1–6 of 24 properties</p>
+        <nav aria-label="Properties navigation">
+          <ul class="pagination mb-0">
+            <li class="page-item active" aria-current="page"><a class="page-link" href="#">1</a></li>
+            <li class="page-item"><a class="page-link" href="#">2</a></li>
+            <li class="page-item"><a class="page-link" href="#">3</a></li>
+            <li class="page-item"><a class="page-link" href="#">4</a></li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+
+  </div>
+
+  <script type="module" src="../js/supabase-client.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
+  <script type="module" src="../js/dashboard_check.js"></script> 
+  <script src="../js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Adds a new properties page (`pages/properties.html`) to manage user properties.

Key changes:
- Page structure includes the standard sidebar and top bar, consistent with other application pages.
- Content is based on the provided HTML, converted to Bootstrap 5 components:
    - Search bar and action buttons (Filter, View options, Add Property).
    - Grid display of property cards.
    - Pagination controls.
- Property cards feature placeholder images (SVGs created as a fallback), property name, address, and task status badges.
- Styling:
    - Leverages Bootstrap 5 for layout and components.
    - Custom CSS class `.property-card-img` added to `css/style.css` for consistent image presentation (height and object-fit).
- Navigation:
    - Sidebar "Properties" link updated across all pages to point to `properties.html`.
    - "Properties" link is marked active when on the properties page.
- Assets:
    - Placeholder SVG images created in `assets/images/` for property cards due to issues with external image fetching.