### PR TITLE
fix: Add space in property card task badges

### DIFF
--- a/pages/properties.html
+++ b/pages/properties.html
@@ -60,7 +60,7 @@
               <h3 class="card-title">Sunset Apartments</h3>
               <p class="card-text text-muted small">123 Maple Street, Seattle, WA</p>
               <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
-                <span class="badge-custom-base badge-custom-red">3 <span data-i18n="propertiesPage.card.tasksLabel">Tasks</span></span>
+                <span class="badge-custom-base badge-custom-red">3&nbsp;<span data-i18n="propertiesPage.card.tasksLabel">Tasks</span></span>
                 <a href="#" class="text-primary small" data-i18n="propertiesPage.card.viewLink">View</a>
               </div>
             </div>
@@ -75,7 +75,7 @@
               <h3 class="card-title">Pine Valley Complex</h3>
               <p class="card-text text-muted small">456 Oak Avenue, Portland, OR</p>
               <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
-                <span class="badge-custom-base badge-custom-yellow">5 <span data-i18n="propertiesPage.card.tasksLabel">Tasks</span></span>
+                <span class="badge-custom-base badge-custom-yellow">5&nbsp;<span data-i18n="propertiesPage.card.tasksLabel">Tasks</span></span>
                 <a href="#" class="text-primary small" data-i18n="propertiesPage.card.viewLink">View</a>
               </div>
             </div>
@@ -105,7 +105,7 @@
               <h3 class="card-title">Highland Park Residences</h3>
               <p class="card-text text-muted small">321 Hill Street, San Francisco, CA</p>
               <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
-                <span class="badge-custom-base badge-custom-red">2 <span data-i18n="propertiesPage.card.tasksLabel">Tasks</span></span>
+                <span class="badge-custom-base badge-custom-red">2&nbsp;<span data-i18n="propertiesPage.card.tasksLabel">Tasks</span></span>
                 <a href="#" class="text-primary small" data-i18n="propertiesPage.card.viewLink">View</a>
               </div>
             </div>
@@ -135,7 +135,7 @@
               <h3 class="card-title">Metropolitan Heights</h3>
               <p class="card-text text-muted small">987 City Center, Los Angeles, CA</p>
               <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
-                <span class="badge-custom-base badge-custom-yellow">4 <span data-i18n="propertiesPage.card.tasksLabel">Tasks</span></span>
+                <span class="badge-custom-base badge-custom-yellow">4&nbsp;<span data-i18n="propertiesPage.card.tasksLabel">Tasks</span></span>
                 <a href="#" class="text-primary small" data-i18n="propertiesPage.card.viewLink">View</a>
               </div>
             </div>


### PR DESCRIPTION
Added a non-breaking space between the task count number and the 'Tasks' label within the badges on property cards in pages/properties.html for improved visual separation.