### PR TITLE
feat: Implement lazy loading and expand property list

### DIFF
--- a/js/lazy-load-properties.js
+++ b/js/lazy-load-properties.js
@@ -1,0 +1,65 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const propertiesContainer = document.querySelector('.properties-page-content .row.g-4');
+    if (!propertiesContainer) {
+        console.warn('Properties container for lazy loading not found.');
+        return;
+    }
+
+    const allCards = Array.from(propertiesContainer.children);
+    const cardsPerLoad = 9;
+    let cardsCurrentlyVisible = 0;
+
+    function hideAllCardsBeyondInitialLoad() {
+        allCards.forEach((card, index) => {
+            if (index >= cardsPerLoad) {
+                card.style.display = 'none';
+            } else {
+                card.style.display = ''; // Ensure first set is visible
+                cardsCurrentlyVisible++;
+            }
+        });
+        // If initially less than cardsPerLoad, all are visible, no scroll listener needed for more
+        if (cardsCurrentlyVisible >= allCards.length) {
+            return false; // No more cards to load
+        }
+        return true; // More cards might be loaded
+    }
+
+    function loadMoreCards() {
+        if (cardsCurrentlyVisible >= allCards.length) {
+            // console.log('All properties loaded.');
+            window.removeEventListener('scroll', scrollHandler); // Remove listener if all loaded
+            return;
+        }
+
+        let newCardsLoadedCount = 0;
+        for (let i = cardsCurrentlyVisible; i < allCards.length && newCardsLoadedCount < cardsPerLoad; i++) {
+            allCards[i].style.display = ''; // Or 'block', 'flex' depending on original display
+            cardsCurrentlyVisible++;
+            newCardsLoadedCount++;
+        }
+        // console.log(`Loaded ${newCardsLoadedCount} more properties. Total visible: ${cardsCurrentlyVisible}`);
+
+        if (cardsCurrentlyVisible >= allCards.length) {
+            window.removeEventListener('scroll', scrollHandler);
+        }
+    }
+
+    const scrollHandler = () => {
+        // Load when user is about 300px from the bottom of the propertiesContainer or document end
+        const buffer = 300; 
+        // Consider either the container's bottom or the document's bottom
+        const containerRect = propertiesContainer.getBoundingClientRect();
+        const triggerPointContainer = containerRect.bottom - window.innerHeight < buffer;
+        const triggerPointDocument = (window.innerHeight + window.scrollY) >= (document.body.offsetHeight - buffer);
+
+
+        if (triggerPointContainer || triggerPointDocument) {
+            loadMoreCards();
+        }
+    };
+    
+    if (hideAllCardsBeyondInitialLoad()) { // Only add scroll listener if there are more cards to load
+        window.addEventListener('scroll', scrollHandler, { passive: true });
+    }
+});

--- a/pages/properties.html
+++ b/pages/properties.html
@@ -141,20 +141,188 @@
             </div>
           </div>
         </div>
+    
+        <!-- Property Card 7 -->
+        <div class="col-12 col-sm-6 col-lg-4">
+          <div class="card h-100 shadow-sm">
+            <img src="../assets/images/card1.png" alt="Willow Creek Estates" class="card-img-top property-card-img">
+            <div class="card-body d-flex flex-column">
+              <h3 class="card-title">Willow Creek Estates</h3>
+              <p class="card-text text-muted small">789 Willow Lane, Springfield, IL</p>
+              <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
+                <span class="badge-custom-base badge-custom-red">1&nbsp;<span data-i18n="propertiesPage.card.tasksLabel">Tasks</span></span>
+                <a href="#" class="text-primary small" data-i18n="propertiesPage.card.viewLink">View</a>
+              </div>
+            </div>
+          </div>
+        </div>
+    
+        <!-- Property Card 8 -->
+        <div class="col-12 col-sm-6 col-lg-4">
+          <div class="card h-100 shadow-sm">
+            <img src="../assets/images/card2.png" alt="Oakwood Plaza" class="card-img-top property-card-img">
+            <div class="card-body d-flex flex-column">
+              <h3 class="card-title">Oakwood Plaza</h3>
+              <p class="card-text text-muted small">101 Oak St, Anytown, TX</p>
+              <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
+                <span class="badge-custom-base badge-custom-green" data-i18n="propertiesPage.card.noActiveTasks">No Active Tasks</span>
+                <a href="#" class="text-primary small" data-i18n="propertiesPage.card.viewLink">View</a>
+              </div>
+            </div>
+          </div>
+        </div>
+    
+        <!-- Property Card 9 -->
+        <div class="col-12 col-sm-6 col-lg-4">
+          <div class="card h-100 shadow-sm">
+            <img src="../assets/images/card3.png" alt="Cedar Heights" class="card-img-top property-card-img">
+            <div class="card-body d-flex flex-column">
+              <h3 class="card-title">Cedar Heights</h3>
+              <p class="card-text text-muted small">222 Cedar Ave, Metro City, CA</p>
+              <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
+                <span class="badge-custom-base badge-custom-yellow">4&nbsp;<span data-i18n="propertiesPage.card.tasksLabel">Tasks</span></span>
+                <a href="#" class="text-primary small" data-i18n="propertiesPage.card.viewLink">View</a>
+              </div>
+            </div>
+          </div>
+        </div>
+    
+        <!-- Property Card 10 -->
+        <div class="col-12 col-sm-6 col-lg-4">
+          <div class="card h-100 shadow-sm">
+            <img src="../assets/images/card4.png" alt="Mapleview Apartments" class="card-img-top property-card-img">
+            <div class="card-body d-flex flex-column">
+              <h3 class="card-title">Mapleview Apartments</h3>
+              <p class="card-text text-muted small">333 Maple Dr, Smallville, KS</p>
+              <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
+                <span class="badge-custom-base badge-custom-red">2&nbsp;<span data-i18n="propertiesPage.card.tasksLabel">Tasks</span></span>
+                <a href="#" class="text-primary small" data-i18n="propertiesPage.card.viewLink">View</a>
+              </div>
+            </div>
+          </div>
+        </div>
+    
+        <!-- Property Card 11 -->
+        <div class="col-12 col-sm-6 col-lg-4">
+          <div class="card h-100 shadow-sm">
+            <img src="../assets/images/card5.png" alt="Birchwood Condos" class="card-img-top property-card-img">
+            <div class="card-body d-flex flex-column">
+              <h3 class="card-title">Birchwood Condos</h3>
+              <p class="card-text text-muted small">444 Birch Rd, Lakeside, MN</p>
+              <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
+                <span class="badge-custom-base badge-custom-yellow">5&nbsp;<span data-i18n="propertiesPage.card.tasksLabel">Tasks</span></span>
+                <a href="#" class="text-primary small" data-i18n="propertiesPage.card.viewLink">View</a>
+              </div>
+            </div>
+          </div>
+        </div>
+    
+        <!-- Property Card 12 -->
+        <div class="col-12 col-sm-6 col-lg-4">
+          <div class="card h-100 shadow-sm">
+            <img src="../assets/images/card6.png" alt="Elm Street Complex" class="card-img-top property-card-img">
+            <div class="card-body d-flex flex-column">
+              <h3 class="card-title">Elm Street Complex</h3>
+              <p class="card-text text-muted small">555 Elm St, Rivertown, OH</p>
+              <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
+                <span class="badge-custom-base badge-custom-green" data-i18n="propertiesPage.card.noActiveTasks">No Active Tasks</span>
+                <a href="#" class="text-primary small" data-i18n="propertiesPage.card.viewLink">View</a>
+              </div>
+            </div>
+          </div>
+        </div>
+    
+        <!-- Property Card 13 -->
+        <div class="col-12 col-sm-6 col-lg-4">
+          <div class="card h-100 shadow-sm">
+            <img src="../assets/images/card1.png" alt="Aspen Grove Lofts" class="card-img-top property-card-img">
+            <div class="card-body d-flex flex-column">
+              <h3 class="card-title">Aspen Grove Lofts</h3>
+              <p class="card-text text-muted small">666 Aspen Way, Mountainview, CO</p>
+              <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
+                <span class="badge-custom-base badge-custom-yellow">3&nbsp;<span data-i18n="propertiesPage.card.tasksLabel">Tasks</span></span>
+                <a href="#" class="text-primary small" data-i18n="propertiesPage.card.viewLink">View</a>
+              </div>
+            </div>
+          </div>
+        </div>
+    
+        <!-- Property Card 14 -->
+        <div class="col-12 col-sm-6 col-lg-4">
+          <div class="card h-100 shadow-sm">
+            <img src="../assets/images/card2.png" alt="Golden Gate Residences" class="card-img-top property-card-img">
+            <div class="card-body d-flex flex-column">
+              <h3 class="card-title">Golden Gate Residences</h3>
+              <p class="card-text text-muted small">777 Bridge Rd, Bay City, CA</p>
+              <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
+                <span class="badge-custom-base badge-custom-red">1&nbsp;<span data-i18n="propertiesPage.card.tasksLabel">Tasks</span></span>
+                <a href="#" class="text-primary small" data-i18n="propertiesPage.card.viewLink">View</a>
+              </div>
+            </div>
+          </div>
+        </div>
+    
+        <!-- Property Card 15 -->
+        <div class="col-12 col-sm-6 col-lg-4">
+          <div class="card h-100 shadow-sm">
+            <img src="../assets/images/card3.png" alt="Silverpine Towers" class="card-img-top property-card-img">
+            <div class="card-body d-flex flex-column">
+              <h3 class="card-title">Silverpine Towers</h3>
+              <p class="card-text text-muted small">888 Pine St, Forestville, OR</p>
+              <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
+                <span class="badge-custom-base badge-custom-green" data-i18n="propertiesPage.card.noActiveTasks">No Active Tasks</span>
+                <a href="#" class="text-primary small" data-i18n="propertiesPage.card.viewLink">View</a>
+              </div>
+            </div>
+          </div>
+        </div>
+    
+        <!-- Property Card 16 -->
+        <div class="col-12 col-sm-6 col-lg-4">
+          <div class="card h-100 shadow-sm">
+            <img src="../assets/images/card4.png" alt="Copperstone Place" class="card-img-top property-card-img">
+            <div class="card-body d-flex flex-column">
+              <h3 class="card-title">Copperstone Place</h3>
+              <p class="card-text text-muted small">999 Copper Ave, Desert Rock, AZ</p>
+              <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
+                <span class="badge-custom-base badge-custom-yellow">4&nbsp;<span data-i18n="propertiesPage.card.tasksLabel">Tasks</span></span>
+                <a href="#" class="text-primary small" data-i18n="propertiesPage.card.viewLink">View</a>
+              </div>
+            </div>
+          </div>
+        </div>
+    
+        <!-- Property Card 17 -->
+        <div class="col-12 col-sm-6 col-lg-4">
+          <div class="card h-100 shadow-sm">
+            <img src="../assets/images/card5.png" alt="Emerald Isle Apartments" class="card-img-top property-card-img">
+            <div class="card-body d-flex flex-column">
+              <h3 class="card-title">Emerald Isle Apartments</h3>
+              <p class="card-text text-muted small">121 Emerald Ct, Greendale, WA</p>
+              <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
+                <span class="badge-custom-base badge-custom-red">2&nbsp;<span data-i18n="propertiesPage.card.tasksLabel">Tasks</span></span>
+                <a href="#" class="text-primary small" data-i18n="propertiesPage.card.viewLink">View</a>
+              </div>
+            </div>
+          </div>
+        </div>
+    
+        <!-- Property Card 18 -->
+        <div class="col-12 col-sm-6 col-lg-4">
+          <div class="card h-100 shadow-sm">
+            <img src="../assets/images/card6.png" alt="Ruby Ridge Condominiums" class="card-img-top property-card-img">
+            <div class="card-body d-flex flex-column">
+              <h3 class="card-title">Ruby Ridge Condominiums</h3>
+              <p class="card-text text-muted small">343 Ruby Ln, Gemstone, NV</p>
+              <div class="d-flex justify-content-between align-items-center mt-auto pt-2">
+                <span class="badge-custom-base badge-custom-yellow">5&nbsp;<span data-i18n="propertiesPage.card.tasksLabel">Tasks</span></span>
+                <a href="#" class="text-primary small" data-i18n="propertiesPage.card.viewLink">View</a>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     
-      <!-- Pagination -->
-      <div class="d-flex justify-content-between align-items-center mt-5">
-        <p class="text-muted small mb-0" data-i18n="propertiesPage.pagination.showingInfo">Showing 1–6 of 24 properties</p>
-        <nav aria-label="Properties navigation">
-          <ul class="pagination mb-0">
-            <li class="page-item active" aria-current="page"><a class="page-link" href="#">1</a></li>
-            <li class="page-item"><a class="page-link" href="#">2</a></li>
-            <li class="page-item"><a class="page-link" href="#">3</a></li>
-            <li class="page-item"><a class="page-link" href="#">4</a></li>
-          </ul>
-        </nav>
-      </div>
     </div>
 
   </div>
@@ -164,5 +332,6 @@
   <script type="module" src="../js/dashboard_check.js"></script> 
   <script src="../js/main.js"></script>
   <script type="module" src="../js/i18n.js"></script>
+  <script src="../js/lazy-load-properties.js"></script>
 </body>
 </html>


### PR DESCRIPTION
- Removed pagination from the properties page (pages/properties.html).
- Added 12 new static property cards, bringing the total to 18, with varied placeholder data and cycling images.
- Implemented lazy loading for property cards:
  - Initially displays 9 cards.
  - Loads the next 9 cards on scroll until all 18 are visible.
  - Logic is contained in `js/lazy-load-properties.js` and integrated into `pages/properties.html`.