### PR TITLE
feat: Standardize sidebar navigation for Tasks page

### DIFF
--- a/pages/properties.html
+++ b/pages/properties.html
@@ -18,7 +18,7 @@
     <ul class="nav-menu">
       <li><a href="dashboard.html"><i class="fas fa-tachometer-alt"></i><span data-i18n="nav.dashboard">Dashboard</span></a></li>
       <li><a href="properties.html" class="active"><i class="fas fa-building"></i><span data-i18n="nav.properties">Properties</span></a></li>
-      <li><a href="#"><i class="fas fa-tasks"></i><span data-i18n="nav.tasks">Tasks</span></a></li>
+      <li><a href="tasks.html"><i class="fas fa-tasks"></i><span data-i18n="nav.tasks">Tasks</span></a></li>
       <li><a href="staff.html"><i class="fas fa-users"></i><span data-i18n="nav.staff">Staff</span></a></li>
       <li><a href="notifications.html"><i class="fas fa-bell"></i><span data-i18n="nav.notifications">Notifications</span></a></li>
       <li id="signOutButtonLi"><button id="signOutButton" class="btn btn-danger" data-i18n="nav.signOut">Sign Out</button></li>


### PR DESCRIPTION
- Updated 'Tasks' link in sidebar to point to tasks.html on:
  - pages/properties.html
  - pages/dashboard.html
  - pages/staff.html
  - pages/notifications.html
  - pages/account.html
- Ensured correct 'active' class management for sidebar links on these pages.
  - Properties link active on properties.html.
  - Dashboard link active on dashboard.html.
  - Staff link active on staff.html.
  - Notifications link active on notifications.html.
  - No sidebar link active on account.html.

Note: This commit is made locally. The push to the remote repository may fail due to authentication. I have provided the file contents for the modified pages so you can update them manually on GitHub.com.