### PR TITLE
Fix: Implement dynamic initial load for properties page

### DIFF
--- a/js/lazy-load-properties.js
+++ b/js/lazy-load-properties.js
@@ -12,48 +12,65 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     const allCards = Array.from(propertiesContainer.children);
-    const cardsPerLoad = 9;
     let cardsCurrentlyVisible = 0;
 
-    function hideAllCardsBeyondInitialLoad() {
-        let visibleCount = 0;
-        allCards.forEach((card, index) => {
-            if (index < cardsPerLoad) {
-                card.style.display = '';
-                visibleCount++;
-            } else {
-                card.style.display = 'none';
-            }
-        });
-        cardsCurrentlyVisible = visibleCount;
-        // console.log(`Initial visible cards: ${cardsCurrentlyVisible}, Total cards: ${allCards.length}`);
+    const initialBufferCards = 3; 
+    const minimumInitialCards = 6; 
+    const cardsPerScrollLoad = 6;
 
-        if (cardsCurrentlyVisible >= allCards.length) {
-            // console.log('All cards are initially visible. No lazy loading needed.');
-            return false;
+    // Initially hide all cards
+    allCards.forEach(card => {
+        card.style.display = 'none';
+    });
+
+    function performInitialPropertyLoad() {
+        console.log('Performing initial property load...');
+        let scrollbarAppeared = false;
+        for (let i = 0; i < allCards.length; i++) {
+            allCards[i].style.display = ''; 
+            cardsCurrentlyVisible++;
+
+            if (cardsCurrentlyVisible >= minimumInitialCards && mainContent.scrollHeight > mainContent.clientHeight) {
+                console.log(`Scrollbar detected after ${cardsCurrentlyVisible} cards. Viewport height: ${mainContent.clientHeight}, Scroll height: ${mainContent.scrollHeight}`);
+                scrollbarAppeared = true;
+                let bufferLoaded = 0;
+                for (let j = i + 1; j < allCards.length && bufferLoaded < initialBufferCards; j++) {
+                    allCards[j].style.display = '';
+                    cardsCurrentlyVisible++;
+                    bufferLoaded++;
+                }
+                console.log(`Loaded ${bufferLoaded} buffer cards. Total visible after initial + buffer: ${cardsCurrentlyVisible}`);
+                break; 
+            }
         }
-        return true;
+
+        if (!scrollbarAppeared && cardsCurrentlyVisible > 0) {
+            console.log(`All ${cardsCurrentlyVisible} cards loaded initially, no scrollbar detected, or not enough cards to trigger scrollbar check past minimum.`);
+        } else if (cardsCurrentlyVisible === 0 && allCards.length > 0) {
+            console.warn('No cards made visible in initial load, but cards exist.');
+        }
+        
+        console.log(`Initial property load complete. Cards visible: ${cardsCurrentlyVisible}/${allCards.length}`);
+        return cardsCurrentlyVisible < allCards.length; // True if more cards to load
     }
 
     function loadMoreCards() {
         if (cardsCurrentlyVisible >= allCards.length) {
-            // This condition is unlikely to be met here if scroll listener is already removed,
-            // but as a safeguard:
             mainContent.removeEventListener('scroll', scrollHandler); 
             return;
         }
 
+        console.log(`Scroll event triggered load. Currently visible: ${cardsCurrentlyVisible}, loading up to ${cardsPerScrollLoad} more.`);
         let newCardsLoadedCount = 0;
-        // console.log(`Attempting to load more cards. Currently visible: ${cardsCurrentlyVisible}`);
-        for (let i = cardsCurrentlyVisible; i < allCards.length && newCardsLoadedCount < cardsPerLoad; i++) {
+        for (let i = cardsCurrentlyVisible; i < allCards.length && newCardsLoadedCount < cardsPerScrollLoad; i++) {
             allCards[i].style.display = '';
             cardsCurrentlyVisible++;
             newCardsLoadedCount++;
         }
-        // console.log(`Loaded ${newCardsLoadedCount} more properties. Total visible: ${cardsCurrentlyVisible}`);
+        console.log(`Loaded ${newCardsLoadedCount} more properties. Total visible: ${cardsCurrentlyVisible}`);
 
         if (cardsCurrentlyVisible >= allCards.length) {
-            console.log('All properties lazy-loaded.');
+            console.log('All properties have been lazy-loaded.');
             mainContent.removeEventListener('scroll', scrollHandler);
         }
     }
@@ -84,10 +101,14 @@ document.addEventListener('DOMContentLoaded', function () {
         }, 50); 
     };
     
-    if (hideAllCardsBeyondInitialLoad()) {
-        // console.log('Scroll listener added to #mainContent.'); // REMOVED
-        mainContent.addEventListener('scroll', scrollHandler, { passive: true }); 
+    if (allCards.length > 0) {
+        if (performInitialPropertyLoad()) { // Returns true if more cards to load
+            console.log('Scroll listener attached for lazy loading remaining properties.');
+            mainContent.addEventListener('scroll', scrollHandler, { passive: true });
+        } else {
+            console.log('All properties fit or were loaded initially. No scroll listener needed.');
+        }
     } else {
-        // console.log('Scroll listener NOT added as all cards are initially visible or elements missing.'); // REMOVED
+        console.warn('No property cards found to lazy load.');
     }
 });


### PR DESCRIPTION
- I modified js/lazy-load-properties.js to dynamically calculate the number of properties to load initially based on screen height.
- This ensures enough cards are loaded to fill your viewport and enable scrolling before further lazy loading on scroll.
- This addresses issues on taller screens (e.g., 2K) where a fixed initial load count was insufficient.