### PR TITLE
Fix: Update Tasks link in staff page sidebar

### DIFF
--- a/pages/staff.html
+++ b/pages/staff.html
@@ -18,7 +18,7 @@
     <ul class="nav-menu">
       <li><a href="dashboard.html"><i class="fas fa-tachometer-alt"></i><span data-i18n="nav.dashboard">Dashboard</span></a></li>
       <li><a href="properties.html"><i class="fas fa-building"></i><span data-i18n="nav.properties">Properties</span></a></li>
-      <li><a href="#"><i class="fas fa-tasks"></i><span data-i18n="nav.tasks">Tasks</span></a></li>
+      <li><a href="tasks.html"><i class="fas fa-tasks"></i><span data-i18n="nav.tasks">Tasks</span></a></li>
       <li><a href="staff.html" class="active"><i class="fas fa-users"></i><span data-i18n="nav.staff">Staff</span></a></li>
       <li><a href="notifications.html"><i class="fas fa-bell"></i><span data-i18n="nav.notifications">Notifications</span></a></li>
       <li id="signOutButtonLi"><button id="signOutButton" class="btn btn-danger" data-i18n="nav.signOut">Sign Out</button></li>


### PR DESCRIPTION
The "Tasks" item in the side navigation menu on `pages/staff.html` was pointing to "#". This commit updates the `href` attribute to point to `tasks.html` as intended.