### PR TITLE
Fix: Update copyright year to be dynamic on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
     </div>
     <!-- End Resend Verification Email Modal -->
 
-    <p class="mt-5 mb-3 text-body-secondary">&copy; 2023-2024 Property Hub</p> <!-- Basic footer -->
+    <p class="mt-5 mb-3 text-body-secondary">&copy; 2023–<span id="currentYear"></span> Property Hub</p> <!-- Basic footer -->
   </main>
 
   <script type="module" src="js/supabase-client.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -23,6 +23,12 @@ document.addEventListener('DOMContentLoaded', function () {
     signUpFormSection.style.display = 'none';  // Hide Sign Up by default
   }
 
+  // Dynamic Year for Footer
+  const currentYearSpan = document.getElementById('currentYear');
+  if (currentYearSpan) {
+    currentYearSpan.textContent = new Date().getFullYear();
+  }
+
   // View Toggling Logic
   if (switchToSignUpLink) {
     switchToSignUpLink.addEventListener('click', function(e) {


### PR DESCRIPTION
Modifies `index.html` and `js/main.js` to ensure the copyright year in the footer automatically displays the current year.

- In `index.html`:
    - The static year in the copyright notice (e.g., "2024") has been wrapped in a `<span>` with `id="currentYear"`. The notice now reads `© 2023–<span id="currentYear"></span> Property Hub`.

- In `js/main.js`:
    - Added JavaScript code within the `DOMContentLoaded` listener to: - Get the `span#currentYear` element. - Set its `textContent` to the current year obtained via `new Date().getFullYear()`.

This ensures the copyright year remains up-to-date automatically.