### PR TITLE
Fix: Display only current year in footer copyright

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
     </div>
     <!-- End Resend Verification Email Modal -->
 
-    <p class="mt-5 mb-3 text-body-secondary">&copy; 2023–<span id="currentYear"></span> Property Hub</p> <!-- Basic footer -->
+    <p class="mt-5 mb-3 text-body-secondary">&copy; <span id="currentYear"></span> Property Hub</p> <!-- Basic footer -->
   </main>
 
   <script type="module" src="js/supabase-client.js"></script>


### PR DESCRIPTION
Updates the copyright notice in the footer of `index.html` to display only the current dynamic year, instead of a range.

- The HTML in `index.html` has been changed from `&copy; 2023–<span id="currentYear"></span> Property Hub` to `&copy; <span id="currentYear"></span> Property Hub`.
- The existing JavaScript in `js/main.js` continues to correctly populate the `span#currentYear` with `new Date().getFullYear()`.

This change reflects the preference to show a single, auto-updating year in the copyright information.