### PR TITLE
feat: Wrap and center index.html content on large screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -382,3 +382,28 @@ The original request was "stroke of all borders", not necessarily hover/active s
 #authToggleContainer a {
     cursor: pointer;
 }
+
+@media (min-width: 1921px) and (min-height: 1081px) {
+  body {
+    /* Ensure the body can center the wrapper if it's smaller than the viewport */
+    display: flex;
+    flex-direction: column; /* Keep normal flow for other body content if any */
+    align-items: center; /* Horizontal centering for the wrapper */
+    justify-content: center; /* Vertical centering for the wrapper */
+    min-height: 100vh; /* Ensure body takes full viewport height for centering to work */
+    margin: 0; /* Reset default body margin */
+  }
+
+  .page-content-wrapper {
+    width: 1200px;
+    height: 200px;
+    margin-top: 20px; /* Add some top margin */
+    margin-bottom: 20px; /* Add some bottom margin */
+    margin-left: auto; /* Horizontal centering if body is not flex/grid parent */
+    margin-right: auto; /* Horizontal centering if body is not flex/grid parent */
+    border: 1px solid #E5E7EB;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    overflow: auto; /* Handle content exceeding the fixed height */
+    background-color: #FFFFFF; /* Added a background color to distinguish from body */
+  }
+}

--- a/index.html
+++ b/index.html
@@ -20,8 +20,8 @@
   </style>
 </head>
 <body class="bg-light">
-
-  <div class="container-fluid vh-100 d-flex p-0">
+  <div class="page-content-wrapper">
+    <div class="container-fluid vh-100 d-flex p-0">
     <div class="row g-0 w-100">
       <!-- Left Branding Panel -->
       <div class="col-lg-6 d-none d-lg-flex flex-column justify-content-center align-items-start p-5 text-white position-relative" id="brandingPanel" style="background-image: url('../assets/images/auth-background.png'); background-size: cover; background-position: center;">
@@ -117,5 +117,6 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script> 
   <script src="js/main.js"></script> 
   <script type="module" src="js/i18n.js"></script>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
I've wrapped the main content of index.html in a new div styled to be 1200px x 200px, centered on the page.

Changes include:
- Added a `div.page-content-wrapper` in `index.html` around the `container-fluid`.
- Added CSS rules in `style.css` for `.page-content-wrapper`:
    - Applied only for screens wider than 1920px and taller than 1080px.
    - Sets width to 1200px and height to 200px.
    - Centers the div on the page using flexbox properties on the body and auto margins.
    - Adds a 1px solid border (#E5E7EB) and a gentle box-shadow.
    - Sets `overflow: auto` to handle content taller than 200px.
    - Sets a white background for the wrapper.
- Body tag is styled with flex properties within the media query to facilitate centering.