### PR TITLE
fix: Update index page layout based on feedback

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -396,7 +396,7 @@ The original request was "stroke of all borders", not necessarily hover/active s
 
   .page-content-wrapper {
     width: 1200px;
-    height: 200px;
+    height: 800px;
     margin-top: 20px; /* Add some top margin */
     margin-bottom: 20px; /* Add some bottom margin */
     margin-left: auto; /* Horizontal centering if body is not flex/grid parent */

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
           </div>
 
           <!-- Sign In Section View -->
-          <div id="signInFormSectionView">
+          <div id="signInFormSectionView" class="mt-5">
             <h2 class="h3 mb-1 fw-semibold" data-i18n="signInPage.formTitle">Sign In</h2>
             <p class="text-muted mb-4" data-i18n="signInPage.formSubtitle">Welcome back! Please enter your details.</p>
             <form id="signInForm">
@@ -62,7 +62,7 @@
           </div>
 
           <!-- Sign Up Section View -->
-          <div id="signUpFormSectionView" style="display: none;">
+          <div id="signUpFormSectionView" class="mt-5" style="display: none;">
             <h2 class="h3 mb-1 fw-semibold" data-i18n="signUpPage.formTitle">Create Account</h2>
             <p class="text-muted mb-4" data-i18n="signUpPage.formSubtitle">Fill out the form below to get started.</p>
             <form id="signUpForm">


### PR DESCRIPTION
Adjusted the main content wrapper height and added spacing to form sections on the index page.

Changes include:
- Modified `.page-content-wrapper` in `css/style.css`:
    - Height changed from 200px to 800px within the large screen media query.
- Modified `index.html`:
    - Added `mt-5` Bootstrap class to `signInFormSectionView` for increased top margin.
    - Added `mt-5` Bootstrap class to `signUpFormSectionView` for increased top margin.