### PR TITLE
Refining: Adjust index page wrapper and container styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -403,7 +403,13 @@ The original request was "stroke of all borders", not necessarily hover/active s
     margin-right: auto; /* Horizontal centering if body is not flex/grid parent */
     border: 1px solid #E5E7EB;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    overflow: auto; /* Handle content exceeding the fixed height */
+    overflow: hidden; /* Handle content exceeding the fixed height */
     background-color: #FFFFFF; /* Added a background color to distinguish from body */
+    border-radius: 8px;
+  }
+
+  .page-content-wrapper .container-fluid {
+    height: 100%; /* Make it take full height of its parent (.page-content-wrapper) */
+    /* This will override the vh-100 class effect within this specific context */
   }
 }


### PR DESCRIPTION
I've updated the styles for the main content wrapper on index.html for large screens:
- Added 8px border-radius to `.page-content-wrapper`.
- Changed `.page-content-wrapper` overflow from `auto` to `hidden` to prevent scrollbars.
- Set the `container-fluid` within `.page-content-wrapper` to `height: 100%` to fit within the wrapper's 800px height, overriding its `vh-100` behavior in this context.

These changes aim to make the content container fit perfectly within the styled wrapper without internal scrollbars on specified screen resolutions.