### PR TITLE
fix: Remove vh-100 from index.html container-fluid

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 </head>
 <body class="bg-light">
   <div class="page-content-wrapper">
-    <div class="container-fluid vh-100 d-flex p-0">
+    <div class="container-fluid d-flex p-0">
     <div class="row g-0 w-100">
       <!-- Left Branding Panel -->
       <div class="col-lg-6 d-none d-lg-flex flex-column justify-content-center align-items-start p-5 text-white position-relative" id="brandingPanel" style="background-image: url('../assets/images/auth-background.png'); background-size: cover; background-position: center;">


### PR DESCRIPTION
I removed the `vh-100` class from the `container-fluid` div within the `page-content-wrapper` on `index.html`.

This change allows the `container-fluid`'s height to be controlled by the CSS rule that sets its height to 100% of its parent (`.page-content-wrapper`) on large screens, ensuring it fits within the wrapper as intended without conflicting viewport height calculations.