### PR TITLE
feat: Conditionally apply 100vh to index container

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -383,6 +383,10 @@ The original request was "stroke of all borders", not necessarily hover/active s
     cursor: pointer;
 }
 
+.page-content-wrapper .container-fluid {
+  height: 100vh; /* Default for smaller screens */
+}
+
 @media (min-width: 1921px) and (min-height: 1081px) {
   body {
     /* Ensure the body can center the wrapper if it's smaller than the viewport */


### PR DESCRIPTION
I've modified the CSS to apply `height: 100vh` to the `container-fluid` within `.page-content-wrapper` by default. This behavior is for screen sizes up to 1920x1080.

For screens larger than 1920x1080, an existing media query overrides this to `height: 100%`, making the container-fluid take the full height of the `.page-content-wrapper` (800px).

The `vh-100` class remains removed from the `index.html` markup, with height control now managed entirely via CSS rules for this element within the specified context.