### PR TITLE
fix: Increase space below authToggleContainer on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
       <div class="col-lg-6 d-flex flex-column justify-content-center align-items-center p-4 p-md-5">
         <div class="w-100" style="max-width: 450px;">
 
-          <div class="d-flex justify-content-end mb-4" id="authToggleContainer">
+          <div class="d-flex justify-content-end" id="authToggleContainer" style="margin-bottom: 120px;">
             <!-- JS will populate this:
             <span class="text-muted me-2" data-i18n="authToggle.dontHaveAccount">Don't have an account yet?</span>
             <a href="#" id="switchToSignUpViewLink" class="fw-bold text-decoration-none" data-i18n="authToggle.signUpLinkText">Sign up</a>
@@ -44,7 +44,7 @@
           </div>
 
           <!-- Sign In Section View -->
-          <div id="signInFormSectionView" class="mt-5">
+          <div id="signInFormSectionView">
             <h2 class="h3 mb-1 fw-semibold" data-i18n="signInPage.formTitle">Sign In</h2>
             <p class="text-muted mb-4" data-i18n="signInPage.formSubtitle">Welcome back! Please enter your details.</p>
             <form id="signInForm">
@@ -62,7 +62,7 @@
           </div>
 
           <!-- Sign Up Section View -->
-          <div id="signUpFormSectionView" class="mt-5" style="display: none;">
+          <div id="signUpFormSectionView" style="display: none;">
             <h2 class="h3 mb-1 fw-semibold" data-i18n="signUpPage.formTitle">Create Account</h2>
             <p class="text-muted mb-4" data-i18n="signUpPage.formSubtitle">Fill out the form below to get started.</p>
             <form id="signUpForm">


### PR DESCRIPTION
I increased the spacing below the authToggleContainer to approximately 120px.

This was achieved by:
- Removing the `mb-4` class from `authToggleContainer`.
- Adding an inline style `margin-bottom: 120px;` to `authToggleContainer`.
- Removing the `mt-5` classes from the `signInFormSectionView` and `signUpFormSectionView` divs to prevent compounded margins.