### PR TITLE
feat: Position authToggleContainer in top-right corner

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,9 +34,9 @@
 
       <!-- Right Form Panel -->
       <div class="col-lg-6 d-flex flex-column justify-content-center align-items-center p-4 p-md-5">
-        <div class="w-100" style="max-width: 450px;">
+        <div class="w-100" style="max-width: 450px; position: relative;">
 
-          <div class="d-flex justify-content-end" id="authToggleContainer" style="margin-bottom: 120px;">
+          <div class="d-flex justify-content-end" id="authToggleContainer" style="position: absolute; top: 0; right: 0;">
             <!-- JS will populate this:
             <span class="text-muted me-2" data-i18n="authToggle.dontHaveAccount">Don't have an account yet?</span>
             <a href="#" id="switchToSignUpViewLink" class="fw-bold text-decoration-none" data-i18n="authToggle.signUpLinkText">Sign up</a>
@@ -44,7 +44,7 @@
           </div>
 
           <!-- Sign In Section View -->
-          <div id="signInFormSectionView">
+          <div id="signInFormSectionView" class="mt-5">
             <h2 class="h3 mb-1 fw-semibold" data-i18n="signInPage.formTitle">Sign In</h2>
             <p class="text-muted mb-4" data-i18n="signInPage.formSubtitle">Welcome back! Please enter your details.</p>
             <form id="signInForm">
@@ -62,7 +62,7 @@
           </div>
 
           <!-- Sign Up Section View -->
-          <div id="signUpFormSectionView" style="display: none;">
+          <div id="signUpFormSectionView" class="mt-5" style="display: none;">
             <h2 class="h3 mb-1 fw-semibold" data-i18n="signUpPage.formTitle">Create Account</h2>
             <p class="text-muted mb-4" data-i18n="signUpPage.formSubtitle">Fill out the form below to get started.</p>
             <form id="signUpForm">


### PR DESCRIPTION
I modified index.html to position the authToggleContainer in the top-right corner of its parent container within the form panel.

Changes include:
- Added `position: relative;` to the parent div of `authToggleContainer`.
- Set `position: absolute; top: 0; right: 0;` on `authToggleContainer` and removed its previous bottom margin style.
- Added `mt-5` class to `signInFormSectionView` and `signUpFormSectionView` to provide top spacing now that `authToggleContainer` is out of the normal document flow.