### PR TITLE
fix: Scope index body styles and adjust form margins

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -388,7 +388,7 @@ The original request was "stroke of all borders", not necessarily hover/active s
 }
 
 @media (min-width: 1921px) and (min-height: 1081px) {
-  body {
+  body.index-page-body {
     /* Ensure the body can center the wrapper if it's smaller than the viewport */
     display: flex;
     flex-direction: column; /* Keep normal flow for other body content if any */

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     }
   </style>
 </head>
-<body class="bg-light">
+<body class="bg-light index-page-body">
   <div class="page-content-wrapper">
     <div class="container-fluid d-flex p-0">
     <div class="row g-0 w-100">
@@ -44,7 +44,7 @@
           </div>
 
           <!-- Sign In Section View -->
-          <div id="signInFormSectionView" class="mt-5">
+          <div id="signInFormSectionView" style="margin-top: 300px;">
             <h2 class="h3 mb-1 fw-semibold" data-i18n="signInPage.formTitle">Sign In</h2>
             <p class="text-muted mb-4" data-i18n="signInPage.formSubtitle">Welcome back! Please enter your details.</p>
             <form id="signInForm">
@@ -62,7 +62,7 @@
           </div>
 
           <!-- Sign Up Section View -->
-          <div id="signUpFormSectionView" class="mt-5" style="display: none;">
+          <div id="signUpFormSectionView" style="margin-top: 300px; display: none;">
             <h2 class="h3 mb-1 fw-semibold" data-i18n="signUpPage.formTitle">Create Account</h2>
             <p class="text-muted mb-4" data-i18n="signUpPage.formSubtitle">Fill out the form below to get started.</p>
             <form id="signUpForm">


### PR DESCRIPTION
This commit includes two main changes:

1. Scoped body styling for large screens to index.html:
   - Added `index-page-body` class to `<body>` tag in `index.html`.
   - Updated the CSS selector in `style.css` within the large-screen media query from `body` to `body.index-page-body`.
   - This prevents the specialized flex centering styles for index.html's main wrapper from affecting the layout of other pages (e.g., dashboard, properties), ensuring they remain full-width.

2. Adjusted top margin for form sections on index.html:
   - Removed `mt-5` class from `signInFormSectionView` and `signUpFormSectionView`.
   - Applied an inline style `margin-top: 300px;` to both sections.
   - This creates a 300px space above these forms, below the absolutely positioned `authToggleContainer`.