### PR TITLE
fix: Correct typo in signUpForm.reset() call

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -156,7 +156,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 signUpUserMessage.textContent = i18next.t('mainJs.signup.success');
                 signUpUserMessage.className = 'alert alert-success';
             }
-            signupForm.reset();
+            signUpForm.reset();
           }
         } else {
           if (resendModal) resendModal.hide();


### PR DESCRIPTION
Fixed a ReferenceError "signupForm is not defined" that occurred during successful user sign-up.

The variable `signupForm` (lowercase 'u') was corrected to `signUpForm` (camelCase 'U' and 'F') to match the declared variable name for the sign-up form element.