### PR TITLE
fix: Update dashboard welcome message format

### DIFF
--- a/js/dashboard_check.js
+++ b/js/dashboard_check.js
@@ -90,7 +90,7 @@
       } else if (profileData) {
         // If first_name is null or empty, provide a generic welcome.
         const displayName = profileData.first_name ? profileData.first_name : 'User';
-        welcomeMessageElement.textContent = i18next.t('dashboardCheckJs.welcomeMessage', { displayName: displayName });
+        welcomeMessageElement.textContent = "Welcome " + displayName + ". We wish you a great day!";
         console.log('Profile data:', profileData);
       } else {
         // This case (no error, no data with .single()) should ideally not happen if RLS allows access


### PR DESCRIPTION
Updated the welcome message string in `js/dashboard_check.js` as per your feedback.

The new format is "Welcome [first_name]. We wish you a great day!".

The `i18next.t` function call was removed for this specific string, meaning this part of the welcome message is no longer translatable without further changes to locale files.