### PR TITLE
fix: Add UI feedback for first_name metadata in sign-up

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -144,24 +144,34 @@ document.addEventListener('DOMContentLoaded', function () {
             }
           }
         } else if (data.user) {
+          let firstNameDebugMessage = " (Debug: first_name NOT seen in user_metadata)";
+          if (data.user.user_metadata && data.user.user_metadata.first_name) {
+            firstNameDebugMessage = " (Debug: first_name '" + data.user.user_metadata.first_name + "' seen in user_metadata)";
+          }
+
           if (data.user.identities && data.user.identities.length === 0) {
             if (signUpUserMessage) {
-                signUpUserMessage.textContent = i18next.t('resendVerification.alertSignupEmailResent', { email: email });
+                signUpUserMessage.textContent = i18next.t('resendVerification.alertSignupEmailResent', { email: email }) + firstNameDebugMessage;
                 signUpUserMessage.className = 'alert alert-info';
             }
             if (resendModal) resendModal.hide();
           } else {
             if (resendModal) resendModal.hide();
             if (signUpUserMessage) {
-                signUpUserMessage.textContent = i18next.t('mainJs.signup.success');
+                signUpUserMessage.textContent = i18next.t('mainJs.signup.success') + firstNameDebugMessage;
                 signUpUserMessage.className = 'alert alert-success';
             }
             signUpForm.reset();
           }
         } else {
+          let firstNameDebugMessage = " (Debug: first_name NOT seen in user_metadata)";
+          // It's unlikely user_metadata would be available here if data.user is not, but for consistency:
+          if (data && data.user && data.user.user_metadata && data.user.user_metadata.first_name) {
+             firstNameDebugMessage = " (Debug: first_name '" + data.user.user_metadata.first_name + "' seen in user_metadata)";
+          }
           if (resendModal) resendModal.hide();
           if (signUpUserMessage) {
-            signUpUserMessage.textContent = i18next.t('mainJs.signup.successUnexpected');
+            signUpUserMessage.textContent = i18next.t('mainJs.signup.successUnexpected') + firstNameDebugMessage;
             signUpUserMessage.className = 'alert alert-info';
           }
         }


### PR DESCRIPTION
I modified `js/main.js` to append debugging information to the sign-up success/info UI messages. This information indicates whether `first_name` (sent in `options.data`) was present in the `user_metadata` of the user object returned by Supabase.

This change is intended to help diagnose issues with `first_name` not being saved, especially when direct console access is limited.