### PR TITLE
fix: Correct syntax error in property-details.js

### DIFF
--- a/js/property-details.js
+++ b/js/property-details.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 
     // Function to display messages to the user
-    functionshowMessage(message, type = 'info') {
+    function showMessage(message, type = 'info') {
         if (!mainContentContainer) return;
         const messageDiv = document.createElement('div');
         messageDiv.className = `alert alert-${type} mt-3`;


### PR DESCRIPTION
- Changed `functionshowMessage` to `function showMessage` in `js/property-details.js`.

This syntax error was preventing the script from executing and populating the property details page.