### PR TITLE
feat: Display property-specific tasks on details page

### DIFF
--- a/js/property-details.js
+++ b/js/property-details.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const propertyDetailsTextElement = document.getElementById('propertyDetailsText');
     // Main content container for showing messages
     const mainContentContainer = document.querySelector('.container.mt-4');
+    const ACTIVE_TASK_STATUSES = ['New', 'Inactive', 'In Progress', 'Stuck'];
 
 
     // Function to display messages to the user
@@ -66,6 +67,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             propertyOccupierElement.textContent = property.property_occupier || 'N/A';
             propertyDetailsTextElement.textContent = property.property_details || 'No additional details provided.';
 
+            if (propertyId) { // Ensure propertyId is valid before fetching tasks
+                fetchAndDisplayTasks(propertyId);
+            }
         } else {
             console.warn('Property not found for ID:', propertyId);
             showMessage('Property not found. The link may be outdated or incorrect.', 'warning');
@@ -74,5 +78,93 @@ document.addEventListener('DOMContentLoaded', async () => {
     } catch (err) {
         console.error('An unexpected error occurred:', err);
         showMessage('An unexpected error occurred while trying to load property details.', 'danger');
+    }
+
+    async function fetchAndDisplayTasks(propertyId) {
+        const activeTasksPane = document.getElementById('active-tasks-pane');
+        const completedTasksPane = document.getElementById('completed-tasks-pane');
+
+        if (!activeTasksPane || !completedTasksPane) {
+            console.error('Task panes not found in the DOM.');
+            return;
+        }
+
+        // Clear initial "Loading..." messages
+        activeTasksPane.innerHTML = '';
+        completedTasksPane.innerHTML = '';
+
+        try {
+            // Fetch tasks for the property
+            const { data: tasks, error: tasksError } = await window._supabase
+                .from('tasks')
+                .select('task_title, task_due_date, status, task_priority, staff_id') // Corrected column names
+                .eq('property_id', propertyId)
+                .order('task_due_date', { ascending: true });
+
+            if (tasksError) {
+                console.error('Error fetching tasks:', tasksError);
+                activeTasksPane.innerHTML = '<p class="text-danger">Error loading tasks.</p>';
+                return;
+            }
+
+            if (!tasks || tasks.length === 0) {
+                activeTasksPane.innerHTML = '<p class="text-muted no-tasks-message">No active tasks.</p>';
+                completedTasksPane.innerHTML = '<p class="text-muted no-tasks-message">No completed tasks.</p>';
+                return;
+            }
+
+            // Fetch staff names
+            const staffIds = [...new Set(tasks.map(task => task.staff_id).filter(id => id))];
+            let staffNamesMap = new Map();
+
+            if (staffIds.length > 0) {
+                const { data: profiles, error: profilesError } = await window._supabase
+                    .from('profiles')
+                    .select('id, first_name, last_name')
+                    .in('id', staffIds);
+
+                if (profilesError) {
+                    console.error('Error fetching profiles:', profilesError);
+                    // Continue without staff names, or show partial error
+                } else {
+                    profiles.forEach(profile => {
+                        staffNamesMap.set(profile.id, `${profile.first_name || ''} ${profile.last_name || ''}`.trim() || 'Unnamed Staff');
+                    });
+                }
+            }
+
+            let activeTasksHtml = [];
+            let completedTasksHtml = [];
+
+            tasks.forEach(task => {
+                const staffName = task.staff_id ? (staffNamesMap.get(task.staff_id) || 'Assignee N/A') : 'Unassigned';
+                const dueDate = task.task_due_date ? new Date(task.task_due_date).toLocaleDateString() : 'No due date';
+                // Basic card structure for a task
+                const taskCardHtml = `
+                    <div class="card mb-2">
+                        <div class="card-body">
+                            <h6 class="card-title">${task.task_title || 'Untitled Task'}</h6>
+                            <p class="card-text mb-1"><small class="text-muted">Assignee: ${staffName}</small></p>
+                            <p class="card-text mb-1"><small class="text-muted">Due: ${dueDate}</small></p>
+                            <p class="card-text mb-1"><small class="text-muted">Priority: ${task.task_priority || 'N/A'}</small></p>
+                            <p class="card-text mb-0"><small class="text-muted">Status: ${task.status || 'N/A'}</small></p>
+                        </div>
+                    </div>
+                `;
+
+                if (task.status === 'Completed') {
+                    completedTasksHtml.push(taskCardHtml);
+                } else if (ACTIVE_TASK_STATUSES.includes(task.status)) {
+                    activeTasksHtml.push(taskCardHtml);
+                }
+            });
+
+            activeTasksPane.innerHTML = activeTasksHtml.length > 0 ? activeTasksHtml.join('') : '<p class="text-muted no-tasks-message">No active tasks.</p>';
+            completedTasksPane.innerHTML = completedTasksHtml.length > 0 ? completedTasksHtml.join('') : '<p class="text-muted no-tasks-message">No completed tasks.</p>';
+
+        } catch (error) {
+            console.error('Unexpected error in fetchAndDisplayTasks:', error);
+            if (activeTasksPane) activeTasksPane.innerHTML = '<p class="text-danger">Could not load tasks due to an unexpected error.</p>';
+        }
     }
 });

--- a/pages/property-details.html
+++ b/pages/property-details.html
@@ -62,6 +62,30 @@
           </ul>
         </div>
       </div>
+
+    <div class="row mt-5"> <!-- New row for the tasks section -->
+      <div class="col-12">
+        <h2>Tasks</h2>
+        <ul class="nav nav-pills mb-3" id="tasksTab" role="tablist">
+          <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="active-tasks-tab" data-bs-toggle="pill" data-bs-target="#active-tasks-pane" type="button" role="tab" aria-controls="active-tasks-pane" aria-selected="true">Active</button>
+          </li>
+          <li class="nav-item" role="presentation">
+            <button class="nav-link" id="completed-tasks-tab" data-bs-toggle="pill" data-bs-target="#completed-tasks-pane" type="button" role="tab" aria-controls="completed-tasks-pane" aria-selected="false">Completed</button>
+          </li>
+        </ul>
+        <div class="tab-content" id="tasksTabContent">
+          <div class="tab-pane fade show active" id="active-tasks-pane" role="tabpanel" aria-labelledby="active-tasks-tab">
+            <!-- Active tasks will be dynamically inserted here -->
+            <p class="text-muted no-tasks-message">Loading active tasks...</p>
+          </div>
+          <div class="tab-pane fade" id="completed-tasks-pane" role="tabpanel" aria-labelledby="completed-tasks-tab">
+            <!-- Completed tasks will be dynamically inserted here -->
+            <p class="text-muted no-tasks-message">Loading completed tasks...</p>
+          </div>
+        </div>
+      </div>
+    </div>
     </div>
   </div>
 


### PR DESCRIPTION
Implemented a new "Tasks" section on the `pages/property-details.html` page that displays tasks associated with the currently viewed property.

Key changes:

- **`pages/property-details.html`**:
    - Added HTML structure for a "Tasks" section.
    - Includes Bootstrap nav pills (tabs) for "Active" and "Completed" task views.
    - Tab content panes (`active-tasks-pane`, `completed-tasks-pane`) are provided for dynamic task rendering.

- **`js/property-details.js`**:
    - Defined `ACTIVE_TASK_STATUSES` array for categorization.
    - Added new `fetchAndDisplayTasks(propertyId)` function:
        - Fetches tasks from the `tasks` table, filtered by `property_id`.
        - Selects `task_title`, `task_due_date`, `status`, `task_priority`, and `staff_id`. - Fetches staff names (`first_name`, `last_name`) from the `profiles` table for assigned tasks using `staff_id`. - Dynamically creates HTML cards for each task, displaying its details (title, assignee, due date, priority, status). - Categorizes tasks into "Active" (New, Inactive, In Progress, Stuck) and "Completed" lists. - Populates the respective tab panes or shows "No active/completed tasks" messages. - Includes error handling for data fetching.
    - The `fetchAndDisplayTasks` function is called after the main property details are successfully loaded.