### PR TITLE
Style: Make form-label elements bold

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -417,3 +417,7 @@ The original request was "stroke of all borders", not necessarily hover/active s
     /* This will override the vh-100 class effect within this specific context */
   }
 }
+
+.form-label {
+  font-weight: bold;
+}


### PR DESCRIPTION
This commit updates the `css/style.css` file to add a new rule that makes all elements with the class `form-label` display with bold text.

This change addresses the issue of making form labels more prominent on the account.html page, and will apply globally to all form labels using this class.