### PR TITLE
refactor: Update user dropdown styling based on feedback

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -421,3 +421,7 @@ The original request was "stroke of all borders", not necessarily hover/active s
 .form-label {
   font-weight: bold;
 }
+
+.dropdown-toggle-no-caret::after {
+  display: none;
+}

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -36,13 +36,13 @@
       <div class="top-bar-icons d-flex align-items-center">
         <a href="notifications.html"><i class="fas fa-bell"></i></a>
         <div class="dropdown">
-          <a class="dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+          <a class="dropdown-toggle dropdown-toggle-no-caret" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
             <i class="fas fa-user-cog"></i>
           </a>
           <ul class="dropdown-menu dropdown-menu-end">
-            <li><a class="dropdown-item" href="account.html">Account Settings</a></li>
+            <li><a class="dropdown-item" href="account.html"><i class="fas fa-cog me-2"></i>Account Settings</a></li>
             <li><hr class="dropdown-divider"></li>
-            <li><a class="dropdown-item" href="#">Sign Out</a></li>
+            <li><a class="dropdown-item" href="#" style="color: red;"><i class="fas fa-sign-out-alt me-2"></i>Sign Out</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
This commit addresses your feedback on the dashboard's user icon dropdown:

- Removed the default Bootstrap dropdown toggle arrow.
- Added a cog icon to the "Account Settings" menu item.
- Added a sign-out icon to the "Sign Out" menu item.
- Changed the "Sign Out" menu item text color to red for emphasis.