### PR TITLE
Refactor: Prevent console logs for optional elements in JS

### DIFF
--- a/js/dashboard_check.js
+++ b/js/dashboard_check.js
@@ -49,8 +49,6 @@
           alert(i18next.t('dashboardCheckJs.signOutUnexpectedError')); 
         }
       });
-    } else { 
-      console.warn('Sign Out button (signOutButton) not found on dashboard page.'); 
     }
   }
   

--- a/js/main.js
+++ b/js/main.js
@@ -183,7 +183,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
       }
     });
-  } else { console.error('signUpForm not found'); }
+  }
 
   // Sign-In Logic (formerly loginForm, ID of form is 'signInForm')
   if (signInForm) {
@@ -250,7 +250,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
       }
     });
-  } else { console.error('signInForm not found'); }
+  }
 
   // Resend Verification Email Modal Logic
   if (resendEmailModalButton) {


### PR DESCRIPTION
I modified `js/main.js` to remove `console.error` messages that would appear if `signUpForm` or `signInForm` elements were not present on a page. The core logic for these forms was already conditional.

I also modified `js/dashboard_check.js` to remove a `console.warn` message that would appear if the `signOutButton` element was not present on a page. The core logic for this button was already conditional.

These changes help to clean up the browser console on pages where these elements are intentionally absent (e.g., dashboard page not having sign-in/sign-up forms).