### PR TITLE
Refactor: Prevent console error for optional welcomeMessage in JS

### DIFF
--- a/js/dashboard_check.js
+++ b/js/dashboard_check.js
@@ -56,7 +56,6 @@
   async function fetchAndDisplayUserProfile(user) {
     const welcomeMessageElement = document.getElementById('welcomeMessage');
     if (!welcomeMessageElement) {
-      console.error('Welcome message element (welcomeMessage) not found.');
       return;
     }
 


### PR DESCRIPTION
I modified `js/dashboard_check.js` within the `fetchAndDisplayUserProfile` function to remove the `console.error` message that would appear if the `welcomeMessage` HTML element was not present on a page.

The function already returned early if the element was not found; this change simply makes that return silent. This cleans up your browser console on pages where this element is intentionally absent.