### PR TITLE
feat: Update property image styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -425,3 +425,17 @@ The original request was "stroke of all borders", not necessarily hover/active s
 .dropdown-toggle-no-caret::after {
   display: none;
 }
+
+#propertyImage {
+  border-radius: 8px;
+  object-fit: cover;
+  max-height: 400px;
+  width: 100%;
+}
+
+@media (min-width: 768px) and (max-width: 1024px) and (orientation: landscape) {
+  #propertyImage {
+    max-height: 300px;
+    width: 80%;
+  }
+}

--- a/pages/property-details.html
+++ b/pages/property-details.html
@@ -51,7 +51,7 @@
       <h1 id="propertyName">[Property Name Loading...]</h1>
       <div class="row">
         <div class="col-md-8">
-          <img id="propertyImage" src="https://via.placeholder.com/700x400.png?text=Loading+Image..." alt="Property Image" class="img-fluid mb-3" style="max-height: 400px; width: 100%; object-fit: cover;">
+          <img id="propertyImage" src="https://via.placeholder.com/700x400.png?text=Loading+Image..." alt="Property Image" class="img-fluid mb-3">
           <h3>Details:</h3>
           <p id="propertyAddressDetails"><strong>Address:</strong> <span id="propertyAddress">[Address Loading...]</span></p>
           <p><strong>Type:</strong> <span id="propertyType">[Type Loading...]</span></p>


### PR DESCRIPTION
- Adds a border-radius of 8px to the property image on the property-details page.
- Adjusts the property image size on tablets in landscape mode to be smaller (max-height: 300px, width: 80%).
- Moves inline image styles to the main stylesheet (css/style.css).