### PR TITLE
fix: Adjust property image height for tablets

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -435,7 +435,7 @@ The original request was "stroke of all borders", not necessarily hover/active s
 
 @media (min-width: 768px) and (max-width: 1024px) and (orientation: landscape) {
   #propertyImage {
-    max-height: 300px;
+    max-height: 200px;
     width: 80%;
   }
 }


### PR DESCRIPTION
Updates the max-height of the property image to 200px for tablets in landscape mode, as per your feedback.