### PR TITLE
fix: Refine property image styles for Samsung Galaxy Tab S7 FE

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -433,7 +433,7 @@ The original request was "stroke of all borders", not necessarily hover/active s
   width: 100%;
 }
 
-@media (min-width: 768px) and (max-width: 1024px) and (orientation: landscape) {
+@media (min-width: 1200px) and (max-width: 1300px) and (orientation: landscape) {
   #propertyImage {
     max-height: 200px;
     width: 80%;


### PR DESCRIPTION
Updates the media query to more accurately target
the Samsung Galaxy Tab S7 FE (and similar sized tablets) in landscape mode.

The property image max-height is set to 200px and
width to 80% for landscape views on devices with
CSS widths between 1200px and 1300px.