### PR TITLE
feat: Add i18n for Add Property modal

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -77,6 +77,35 @@
     },
     "pagination": {
       "showingInfo": "Zeige {start}–{end} von {total} Immobilien"
+    },
+    "modal": {
+      "addTitle": "Neue Immobilie hinzufügen",
+      "propertyNameLabel": "Immobilienname",
+      "addressLabel": "Adresse",
+      "typeLabel": "Immobilientyp",
+      "typePlaceholder": "z.B. Wohnung, Haus, Eigentumswohnung",
+      "rentPriceLabel": "Miete/Preis (USD)",
+      "bedroomsLabel": "Schlafzimmer",
+      "bathroomsLabel": "Badezimmer",
+      "sqftLabel": "Quadratmeter (qmf)",
+      "descriptionLabel": "Beschreibung",
+      "imageLabel": "Immobilienbild",
+      "imagePreviewAlt": "Bildvorschau",
+      "closeButton": "Schließen",
+      "saveButton": "Immobilie speichern",
+      "savingButton": "Speichern...",
+      "nameAddressTypeRequired": "Immobilienname, Adresse und Immobilientyp sind erforderlich.",
+      "imageRequiredError": "Immobilienbild ist erforderlich.",
+      "imageSizeError": "Die Bilddateigröße darf 5MB nicht überschreiten.",
+      "successMessage": "Immobilie erfolgreich erstellt!",
+      "functionErrorPrefix": "Immobilie konnte nicht erstellt werden: ",
+      "validationFailedTitle": "Validierung fehlgeschlagen:",
+      "userNotAuthError": "Benutzer nicht authentifiziert. Bild kann nicht hochgeladen oder Immobilie erstellt werden.",
+      "imageUploadFailedError": "Bild-Upload fehlgeschlagen: {message}",
+      "publicUrlFailedError": "Öffentliche URL des Bildes konnte nicht abgerufen werden: {message}",
+      "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten.",
+      "unexpectedServerError": "Immobilie konnte aufgrund eines unerwarteten Serverfehlers nicht erstellt werden.",
+      "networkError": "Immobilie konnte nicht erstellt werden. Netzwerk- oder Funktionsfehler."
     }
   },
   "notificationsPage": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -77,6 +77,35 @@
     },
     "pagination": {
       "showingInfo": "Showing {start}–{end} of {total} properties"
+    },
+    "modal": {
+      "addTitle": "Add New Property",
+      "propertyNameLabel": "Property Name",
+      "addressLabel": "Address",
+      "typeLabel": "Property Type",
+      "typePlaceholder": "e.g., Apartment, House, Condo",
+      "rentPriceLabel": "Rent/Price (USD)",
+      "bedroomsLabel": "Bedrooms",
+      "bathroomsLabel": "Bathrooms",
+      "sqftLabel": "Square Footage (sqft)",
+      "descriptionLabel": "Description",
+      "imageLabel": "Property Image",
+      "imagePreviewAlt": "Image Preview",
+      "closeButton": "Close",
+      "saveButton": "Save Property",
+      "savingButton": "Saving...",
+      "nameAddressTypeRequired": "Property Name, Address, and Type are required.",
+      "imageRequiredError": "Property image is required.",
+      "imageSizeError": "Image file size should not exceed 5MB.",
+      "successMessage": "Property created successfully!",
+      "functionErrorPrefix": "Failed to create property: ",
+      "validationFailedTitle": "Validation failed:",
+      "userNotAuthError": "User not authenticated. Cannot upload image or create property.",
+      "imageUploadFailedError": "Image upload failed: {message}",
+      "publicUrlFailedError": "Failed to get image public URL: {message}",
+      "unexpectedError": "An unexpected error occurred.",
+      "unexpectedServerError": "Failed to create property due to an unexpected server response.",
+      "networkError": "Failed to create property. Network or function error."
     }
   },
   "notificationsPage": {


### PR DESCRIPTION
I've added translations for the 'Add New Property' modal elements and related JavaScript messages in both English and German.

- I identified all necessary internationalization keys from the modal's HTML in `pages/properties.html` and messages in `js/addProperty.js`.
- I updated `locales/en.json` with English translations under `propertiesPage.modal`.
- I updated `locales/de.json` with corresponding German translations under `propertiesPage.modal`.

This ensures that your new 'Add Property' feature is internationalized and displays text according to the selected language.