### PR TITLE
Feature: Update 'Add New Property' modal fields

### DIFF
--- a/js/addProperty.js
+++ b/js/addProperty.js
@@ -45,17 +45,16 @@ document.addEventListener('DOMContentLoaded', () => {
         property_name: document.getElementById('propertyName').value,
         address: document.getElementById('propertyAddress').value,
         property_type: document.getElementById('propertyType').value,
+        occupier: document.getElementById('propertyOccupier').value, // Added
         rent_price: parseFloat(document.getElementById('propertyRentPrice').value) || null,
-        bedrooms: parseInt(document.getElementById('propertyBedrooms').value) || null,
-        bathrooms: parseFloat(document.getElementById('propertyBathrooms').value) || null,
-        square_footage: parseInt(document.getElementById('propertySquareFootage').value) || null,
+        // bedrooms, bathrooms, square_footage removed
         description: document.getElementById('propertyDescription').value,
         imageFile: propertyImageFile.files[0] // The actual file object
       };
 
       // --- Basic Client-Side Validation (enhance as needed) ---
-      if (!formData.property_name || !formData.address || !formData.property_type) {
-        showMessage('Property Name, Address, and Type are required.', 'danger');
+      if (!formData.property_name || !formData.address || !formData.property_type || !formData.occupier) { // Added occupier
+        showMessage('Property Name, Address, Property Type, and Occupier are required.', 'danger'); // Updated message
         submitButton.disabled = false;
         submitButton.innerHTML = 'Save Property';
         return;
@@ -119,12 +118,11 @@ document.addEventListener('DOMContentLoaded', () => {
           property_name: formData.property_name,
           address: formData.address,
           property_type: formData.property_type,
+          occupier: formData.occupier, // Add new field
           rent_price: formData.rent_price,
-          bedrooms: formData.bedrooms,
-          bathrooms: formData.bathrooms,
-          square_footage: formData.square_footage,
+          // bedrooms, bathrooms, square_footage are removed
           description: formData.description,
-          property_image_url: imageUrl // This now matches the corrected Edge Function
+          property_image_url: imageUrl
         };
 
         // 3. Call the 'create-property' Edge Function

--- a/pages/properties.html
+++ b/pages/properties.html
@@ -91,27 +91,26 @@
             <div class="row">
               <div class="col-md-6 mb-3">
                 <label for="propertyType" class="form-label" data-i18n="propertiesPage.modal.typeLabel">Property Type</label>
-                <input type="text" class="form-control" id="propertyType" placeholder="e.g., Apartment, House, Condo" required>
-                {/* Or use a <select> if you have predefined types */}
+                <select class="form-select" id="propertyType" required>
+                  <option value="" selected disabled data-i18n="propertiesPage.modal.selectTypeOption">Select type...</option>
+                  <option value="House" data-i18n="propertiesPage.modal.typeHouse">House</option>
+                  <option value="Apartment" data-i18n="propertiesPage.modal.typeApartment">Apartment</option>
+                </select>
               </div>
               <div class="col-md-6 mb-3">
-                <label for="propertyRentPrice" class="form-label" data-i18n="propertiesPage.modal.rentPriceLabel">Rent/Price (USD)</label>
-                <input type="number" class="form-control" id="propertyRentPrice" step="0.01" min="0">
+                <label for="propertyOccupier" class="form-label" data-i18n="propertiesPage.modal.occupierLabel">Occupier</label>
+                <select class="form-select" id="propertyOccupier" required>
+                  <option value="" selected disabled data-i18n="propertiesPage.modal.selectOccupierOption">Select occupier...</option>
+                  <option value="Owner" data-i18n="propertiesPage.modal.occupierOwner">Owner</option>
+                  <option value="Tenant" data-i18n="propertiesPage.modal.occupierTenant">Tenant</option>
+                </select>
               </div>
             </div>
 
             <div class="row">
-              <div class="col-md-4 mb-3">
-                <label for="propertyBedrooms" class="form-label" data-i18n="propertiesPage.modal.bedroomsLabel">Bedrooms</label>
-                <input type="number" class="form-control" id="propertyBedrooms" min="0">
-              </div>
-              <div class="col-md-4 mb-3">
-                <label for="propertyBathrooms" class="form-label" data-i18n="propertiesPage.modal.bathroomsLabel">Bathrooms</label>
-                <input type="number" class="form-control" id="propertyBathrooms" step="0.5" min="0">
-              </div>
-              <div class="col-md-4 mb-3">
-                <label for="propertySquareFootage" class="form-label" data-i18n="propertiesPage.modal.sqftLabel">Square Footage (sqft)</label>
-                <input type="number" class="form-control" id="propertySquareFootage" min="0">
+              <div class="col-md-12 mb-3">
+                <label for="propertyRentPrice" class="form-label" data-i18n="propertiesPage.modal.rentPriceLabel">Rent/Price (USD)</label>
+                <input type="number" class="form-control" id="propertyRentPrice" step="0.01" min="0">
               </div>
             </div>
 


### PR DESCRIPTION
I've modified the 'Add New Property' modal in `pages/properties.html` and its corresponding JavaScript logic in `js/addProperty.js` as you requested:

- Changed 'Property Type' from a text input to a select dropdown with options "House" and "Apartment".
- Added a new 'Occupier' select dropdown next to 'Property Type' with options "Owner" and "Tenant".
- Removed the input fields and labels for 'Bedrooms', 'Bathrooms', and 'Square Footage'.
- Removed the comment below the 'Property Type' field.
- Updated `js/addProperty.js` to:
    - Correctly read values from the new dropdowns.
    - Remove logic for the deleted fields.
    - Include 'Occupier' in client-side validation and the payload sent to the 'create-property' Edge Function.
    - Exclude 'Bedrooms', 'Bathrooms', and 'Square Footage' from the payload.

The 'Rent/Price' field was repositioned to its own row due to the layout changes. I've noted that potential backend adjustments for the 'create-property' Edge Function and database schema (to handle the new 'occupier' field and the absence of removed fields) may be needed, but I haven't implemented them in this commit.