### PR TITLE
Okay, I've removed the 'Rent/Price (USD)' field from the 'Add New Pro…

### DIFF
--- a/js/addProperty.js
+++ b/js/addProperty.js
@@ -46,7 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
         address: document.getElementById('propertyAddress').value,
         property_type: document.getElementById('propertyType').value,
         occupier: document.getElementById('propertyOccupier').value, // Added
-        rent_price: parseFloat(document.getElementById('propertyRentPrice').value) || null,
+        // rent_price removed
         // bedrooms, bathrooms, square_footage removed
         description: document.getElementById('propertyDescription').value,
         imageFile: propertyImageFile.files[0] // The actual file object
@@ -119,7 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
           address: formData.address,
           property_type: formData.property_type,
           occupier: formData.occupier, // Add new field
-          rent_price: formData.rent_price,
+          // rent_price removed
           // bedrooms, bathrooms, square_footage are removed
           description: formData.description,
           property_image_url: imageUrl

--- a/pages/properties.html
+++ b/pages/properties.html
@@ -107,13 +107,6 @@
               </div>
             </div>
 
-            <div class="row">
-              <div class="col-md-12 mb-3">
-                <label for="propertyRentPrice" class="form-label" data-i18n="propertiesPage.modal.rentPriceLabel">Rent/Price (USD)</label>
-                <input type="number" class="form-control" id="propertyRentPrice" step="0.01" min="0">
-              </div>
-            </div>
-
             <div class="mb-3">
               <label for="propertyDescription" class="form-label" data-i18n="propertiesPage.modal.descriptionLabel">Description</label>
               <textarea class="form-control" id="propertyDescription" rows="3"></textarea>


### PR DESCRIPTION
…perty' modal as you requested.

Here's what I changed:
- In `pages/properties.html`, I deleted the HTML row for the `propertyRentPrice` field.
- In `js/addProperty.js`:
    - I removed the part that reads the `propertyRentPrice` field.
    - I also removed the `rent_price` key from the data sent to the 'create-property' function.

This should work assuming the backend can handle requests without the `rent_price` field.