### PR TITLE
Fix: Add missing i18n translations for 'Add New Property' modal

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -105,7 +105,14 @@
       "publicUrlFailedError": "Öffentliche URL des Bildes konnte nicht abgerufen werden: {message}",
       "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten.",
       "unexpectedServerError": "Immobilie konnte aufgrund eines unerwarteten Serverfehlers nicht erstellt werden.",
-      "networkError": "Immobilie konnte nicht erstellt werden. Netzwerk- oder Funktionsfehler."
+      "networkError": "Immobilie konnte nicht erstellt werden. Netzwerk- oder Funktionsfehler.",
+      "selectTypeOption": "Typ auswählen...",
+      "typeHouse": "Haus",
+      "typeApartment": "Wohnung",
+      "occupierLabel": "Nutzer",
+      "selectOccupierOption": "Nutzer auswählen...",
+      "occupierOwner": "Eigentümer",
+      "occupierTenant": "Mieter"
     }
   },
   "notificationsPage": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -105,7 +105,14 @@
       "publicUrlFailedError": "Failed to get image public URL: {message}",
       "unexpectedError": "An unexpected error occurred.",
       "unexpectedServerError": "Failed to create property due to an unexpected server response.",
-      "networkError": "Failed to create property. Network or function error."
+      "networkError": "Failed to create property. Network or function error.",
+      "selectTypeOption": "Select type...",
+      "typeHouse": "House",
+      "typeApartment": "Apartment",
+      "occupierLabel": "Occupier",
+      "selectOccupierOption": "Select occupier...",
+      "occupierOwner": "Owner",
+      "occupierTenant": "Tenant"
     }
   },
   "notificationsPage": {


### PR DESCRIPTION
Added missing internationalization keys and their translations to `locales/en.json` and `locales/de.json` for the 'Add New Property' modal.

This addresses an issue where raw i18n keys were displayed in the UI for the 'Property Type' and 'Occupier' fields after recent modifications to the modal.

The following keys were added:
- propertiesPage.modal.selectTypeOption
- propertiesPage.modal.typeHouse
- propertiesPage.modal.typeApartment
- propertiesPage.modal.occupierLabel
- propertiesPage.modal.selectOccupierOption
- propertiesPage.modal.occupierOwner
- propertiesPage.modal.occupierTenant

These changes ensure that the modal displays correctly translated text in both English and German.