### PR TITLE
Fix: Correct syntax error in addProperty.js

### DIFF
--- a/js/addProperty.js
+++ b/js/addProperty.js
@@ -160,10 +160,8 @@ ${Object.values(errJson.errors).map(e => `- ${e}`).join('
         // This check is more for functions that don't use HTTP status codes for errors
         if (functionResponseData && functionResponseData.error) {
           if (functionResponseData.errors) { // Our structured validation errors
-            const messages = Object.values(functionResponseData.errors).map(e => `- ${e}`).join('
-');
-            throw new Error(`Validation failed:
-${messages}`);
+            const messages = Object.values(functionResponseData.errors).map(e => `- ${e}`).join('\n');
+            throw new Error(`Validation failed:\n${messages}`);
           }
           throw new Error(functionResponseData.error);
         }


### PR DESCRIPTION
I corrected a JavaScript syntax error in `js/addProperty.js` that was preventing properties from being added. The error was caused by an unescaped newline character within a string literal in the `join()` method (around line 132).

I changed `join('\n')` to use the correct `\n` escape sequence for newlines. This resolves the "Invalid or unexpected token" error.