### PR TITLE
Fix: Correct persistent syntax error in addProperty.js

### DIFF
--- a/js/addProperty.js
+++ b/js/addProperty.js
@@ -138,9 +138,7 @@ document.addEventListener('DOMContentLoaded', () => {
             try {
               const errJson = await functionInvokeError.context.json();
               if (errJson.error && errJson.errors) { // Our specific validation structure
-                errMsg = `Validation failed:
-${Object.values(errJson.errors).map(e => `- ${e}`).join('
-')}`;
+                errMsg = `Validation failed:\n${Object.values(errJson.errors).map(e => `- ${e}`).join('\n')}`;
               } else if (errJson.error) {
                 errMsg = errJson.error;
               }


### PR DESCRIPTION
This commit addresses a lingering syntax error in `js/addProperty.js` that was causing "Invalid or unexpected token" errors. The issue was an unescaped newline character within a string literal used in a `join()` method.

The specific correction was made in the `errMsg` assignment within the `if (functionInvokeError)` block (around line 112). The `join(' ')` (with a literal newline) was changed to `join('\n')`.

A previous attempt had fixed a similar issue elsewhere in the file, but this instance was missed. This change should now fully resolve the reported syntax error.