### PR TITLE
Fix: Correct selector for the button in addProperty.js

### DIFF
--- a/js/addProperty.js
+++ b/js/addProperty.js
@@ -37,7 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
       addPropertyMessage.textContent = '';
       addPropertyMessage.className = 'alert'; // Reset classes
 
-      const submitButton = addPropertyForm.querySelector('button[type="submit"]');
+      const submitButton = document.querySelector('button[type="submit"][form="addPropertyForm"]');
       submitButton.disabled = true;
       submitButton.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Saving...';
 


### PR DESCRIPTION
I changed the JavaScript selector for the 'Save Property' button in `js/addProperty.js` to correctly find the button even when it's outside the <form> tag but associated via the 'form' attribute.

The selector was changed from `addPropertyForm.querySelector('button[type="submit"]')` to `document.querySelector('button[type="submit"][form="addPropertyForm"]')`.

This resolves a TypeError "Cannot set properties of null (setting 'disabled')" that occurred because the previous selector couldn't find the button in the modal's footer.