### PR TITLE
Fix: Align description payload key with backend expectation

### DIFF
--- a/js/addProperty.js
+++ b/js/addProperty.js
@@ -121,7 +121,7 @@ document.addEventListener('DOMContentLoaded', () => {
           occupier: formData.occupier, // Add new field
           // rent_price removed
           // bedrooms, bathrooms, square_footage are removed
-          description: formData.description,
+          property_details: formData.description, // Key changed here
           property_image_url: imageUrl
         };
 


### PR DESCRIPTION
I updated `js/addProperty.js` to send the description field under the key `property_details` instead of `description` in the payload to the 'create-property' Edge Function.

This change aligns the frontend with the backend schema, which expects the description data under `property_details`. The UI label and form field ID remain 'Description' (`propertyDescription`) as per your request.