### PR TITLE
Fix: Align 'occupier' payload key with backend schema

### DIFF
--- a/js/addProperty.js
+++ b/js/addProperty.js
@@ -146,7 +146,7 @@ document.addEventListener('DOMContentLoaded', () => {
           property_name: formData.property_name,
           address: formData.address,
           property_type: formData.property_type,
-          occupier: formData.occupier, // Add new field
+          property_occupier: formData.occupier, // Key changed here
           // rent_price removed
           // bedrooms, bathrooms, square_footage are removed
           property_details: formData.description, // Key changed here


### PR DESCRIPTION
I've updated `js/addProperty.js` to send the occupier field under the key `property_occupier` instead of `occupier` in the payload to the 'create-property' Edge Function.

This change aligns the frontend with the expected database column name `property_occupier`. The UI label and form field ID for 'Occupier' (`propertyOccupier`) remain unchanged.

You must ensure your 'create-property' Edge Function is also updated to expect and use `property_occupier` when processing the payload and inserting into the database.