### PR TITLE
Style: Make top-bar sticky

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -80,6 +80,9 @@ body {
   border-bottom: 1px solid #E5E7EB; /* Optional border */
   height: 60px; /* Adjust height as needed */
   box-sizing: border-box;
+  position: sticky;
+  top: 0;
+  z-index: 1020;
 }
 
 .top-bar .page-title span {


### PR DESCRIPTION
I've updated `css/style.css` to make the `.top-bar` element sticky. I added the following properties to the `.top-bar` rule:
- position: sticky;
- top: 0;
- z-index: 1020;

This will ensure the top bar remains visible at the top of the main content area when you're scrolling on pages within the `pages/` folder.