### PR TITLE
feat: Add dropdown menu to property details page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -85,6 +85,17 @@ body {
   z-index: 1020;
 }
 
+.page-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%; /* Ensure it takes full width to push the icon to the far right */
+}
+
+.page-title .dropdown {
+  margin-left: 10px; /* Add some space between title and dropdown icon */
+}
+
 .top-bar .page-title span {
   font-size: 1.2em; /* Adjust as needed */
   color: #495057; /* Darker grey for text, adjust as needed */

--- a/js/property-details.js
+++ b/js/property-details.js
@@ -167,4 +167,38 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (activeTasksPane) activeTasksPane.innerHTML = '<p class="text-danger">Could not load tasks due to an unexpected error.</p>';
         }
     }
+
+    // Event listeners for the new dropdown menu items
+    const editPropertyLink = document.getElementById('editPropertyLink');
+    const addTaskLink = document.getElementById('addTaskLink');
+    const deletePropertyLink = document.getElementById('deletePropertyLink');
+
+    if (editPropertyLink) {
+        editPropertyLink.addEventListener('click', (event) => {
+            event.preventDefault(); // Prevent default link behavior
+            console.log('Edit Property clicked');
+            // Future implementation: Redirect to edit page or open modal
+        });
+    }
+
+    if (addTaskLink) {
+        addTaskLink.addEventListener('click', (event) => {
+            event.preventDefault(); // Prevent default link behavior
+            console.log('Add Task clicked');
+            // Future implementation: Redirect to add task page or open modal
+        });
+    }
+
+    if (deletePropertyLink) {
+        deletePropertyLink.addEventListener('click', (event) => {
+            event.preventDefault(); // Prevent default link behavior
+            if (confirm('Are you sure you want to delete this property?')) {
+                console.log('Delete Property confirmed');
+                // Future implementation: Call Supabase to delete the property
+                // and then redirect or update UI.
+            } else {
+                console.log('Delete Property cancelled');
+            }
+        });
+    }
 });

--- a/pages/property-details.html
+++ b/pages/property-details.html
@@ -31,6 +31,17 @@
       </button>
       <div class="page-title">
         <span>Property Details</span>
+        <div class="dropdown">
+          <a class="dropdown-toggle dropdown-toggle-no-caret" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            <i class="fas fa-ellipsis-v"></i>
+          </a>
+          <ul class="dropdown-menu dropdown-menu-end">
+            <li><a class="dropdown-item" href="#" id="editPropertyLink"><i class="fas fa-edit me-2"></i>Edit Property</a></li>
+            <li><a class="dropdown-item" href="#" id="addTaskLink"><i class="fas fa-plus-circle me-2"></i>Add Task</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><a class="dropdown-item" href="#" id="deletePropertyLink" style="color: red;"><i class="fas fa-trash-alt me-2"></i>Delete Property</a></li>
+          </ul>
+        </div>
       </div>
       <div class="top-bar-icons d-flex align-items-center">
         <a href="notifications.html"><i class="fas fa-bell"></i></a>
@@ -60,14 +71,6 @@
             <h4>Property Description/Notes:</h4>
             <div id="propertyDetailsText" style="white-space: pre-wrap;">[Details Loading...]</div>
           </div>
-        </div>
-        <div class="col-md-4">
-          <!-- Potential sidebar for actions or related info later -->
-          <h4>Related Actions (Future)</h4>
-          <ul class="list-group">
-            <li class="list-group-item"><a>Create Task for this Property</a></li>
-            <li class="list-group-item"><a>Edit Property Details</a></li>
-          </ul>
         </div>
       </div>
 


### PR DESCRIPTION
Implements a new dropdown menu on the property-details.html page, providing options to "Edit Property", "Add Task", and "Delete Property".

Key changes:
- Added HTML structure for the dropdown menu in `pages/property-details.html`, using a Font Awesome "vertical ellipsis" icon.
- Styled the "Delete Property" option with red text and a separator, consistent with the existing account settings dropdown.
- Positioned the dropdown to the right of the page title using CSS enhancements in `css/style.css`.
- Added JavaScript stubs in `js/property-details.js` for each menu action, including a confirmation dialog for deletion.
- Removed the previous "Related Actions (Future)" placeholder.

The new dropdown enhances user interaction on the property details page by grouping relevant actions in a consistent and accessible manner.