### PR TITLE
fix: Relocate property details dropdown menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -85,17 +85,6 @@ body {
   z-index: 1020;
 }
 
-.page-title {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%; /* Ensure it takes full width to push the icon to the far right */
-}
-
-.page-title .dropdown {
-  margin-left: 10px; /* Add some space between title and dropdown icon */
-}
-
 .top-bar .page-title span {
   font-size: 1.2em; /* Adjust as needed */
   color: #495057; /* Darker grey for text, adjust as needed */

--- a/pages/property-details.html
+++ b/pages/property-details.html
@@ -31,17 +31,6 @@
       </button>
       <div class="page-title">
         <span>Property Details</span>
-        <div class="dropdown">
-          <a class="dropdown-toggle dropdown-toggle-no-caret" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-            <i class="fas fa-ellipsis-v"></i>
-          </a>
-          <ul class="dropdown-menu dropdown-menu-end">
-            <li><a class="dropdown-item" href="#" id="editPropertyLink"><i class="fas fa-edit me-2"></i>Edit Property</a></li>
-            <li><a class="dropdown-item" href="#" id="addTaskLink"><i class="fas fa-plus-circle me-2"></i>Add Task</a></li>
-            <li><hr class="dropdown-divider"></li>
-            <li><a class="dropdown-item" href="#" id="deletePropertyLink" style="color: red;"><i class="fas fa-trash-alt me-2"></i>Delete Property</a></li>
-          </ul>
-        </div>
       </div>
       <div class="top-bar-icons d-flex align-items-center">
         <a href="notifications.html"><i class="fas fa-bell"></i></a>
@@ -59,7 +48,20 @@
     </div>
 
     <div class="container mt-4">
-      <h1 id="propertyName">[Property Name Loading...]</h1>
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h1 id="propertyName" class="mb-0">[Property Name Loading...]</h1>
+        <div class="dropdown">
+          <a class="dropdown-toggle dropdown-toggle-no-caret" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            <i class="fas fa-ellipsis-v"></i>
+          </a>
+          <ul class="dropdown-menu dropdown-menu-end">
+            <li><a class="dropdown-item" href="#" id="editPropertyLink"><i class="fas fa-edit me-2"></i>Edit Property</a></li>
+            <li><a class="dropdown-item" href="#" id="addTaskLink"><i class="fas fa-plus-circle me-2"></i>Add Task</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><a class="dropdown-item" href="#" id="deletePropertyLink" style="color: red;"><i class="fas fa-trash-alt me-2"></i>Delete Property</a></li>
+          </ul>
+        </div>
+      </div>
       <div class="row">
         <div class="col-md-8">
           <img id="propertyImage" src="https://via.placeholder.com/700x400.png?text=Loading+Image..." alt="Property Image" class="img-fluid mb-3">


### PR DESCRIPTION
Corrects the placement of the property actions dropdown menu on the property-details.html page.

The dropdown menu was previously, and incorrectly, implemented within the top navigation bar's page title. This commit moves the dropdown menu into the main content area, positioning it directly in line with the H1 property name (`#propertyName`), aligned to the right.

Changes include:
- Modified `pages/property-details.html`:
    - Removed the dropdown from `div.page-title` in the top bar.
    - Wrapped `h1#propertyName` and the dropdown in a new `div` using Bootstrap flexbox utilities (`d-flex justify-content-between align-items-center`) for correct alignment.
- Modified `css/style.css`:
    - Removed CSS rules previously added for styling the dropdown in its incorrect top-bar location. No new CSS was required due to the use of Bootstrap utilities.