### PR TITLE
style: Increase size of property actions dropdown icon

### DIFF
--- a/pages/property-details.html
+++ b/pages/property-details.html
@@ -52,7 +52,7 @@
         <h1 id="propertyName" class="mb-0">[Property Name Loading...]</h1>
         <div class="dropdown">
           <a class="dropdown-toggle dropdown-toggle-no-caret" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-            <i class="fas fa-ellipsis-v"></i>
+            <i class="fas fa-ellipsis-v fa-2x"></i>
           </a>
           <ul class="dropdown-menu dropdown-menu-end">
             <li><a class="dropdown-item" href="#" id="editPropertyLink"><i class="fas fa-edit me-2"></i>Edit Property</a></li>


### PR DESCRIPTION
Increases the size of the vertical ellipsis icon used for the property actions dropdown menu on the `property-details.html` page.

This change is made by adding the `fa-2x` class from Font Awesome to the icon element, effectively doubling its size to improve visibility and touch-friendliness.