### PR TITLE
feat: Implement frontend for Edit Property functionality

### DIFF
--- a/pages/properties.html
+++ b/pages/properties.html
@@ -77,6 +77,7 @@
         <div class="modal-body">
           <form id="addPropertyForm">
             <div id="addPropertyMessage" class="alert" style="display:none;" role="alert"></div>
+            <input type="hidden" id="propertyIdStore">
 
             <div class="mb-3">
               <label for="propertyName" class="form-label" data-i18n="propertiesPage.modal.propertyNameLabel">Property Name</label>


### PR DESCRIPTION
This commit introduces the frontend logic to enable editing of property details using the existing "Add Property" modal.

Key changes:

1.  **`pages/properties.html`**:
    *   Added a hidden input field `#propertyIdStore` to the
      `#addPropertyForm` to store the ID of the property being edited.

2.  **`js/addProperty.js`**:
    *   Refactored to support both 'add' and 'edit' modes.
    *   Introduced state variables (`currentMode`, `editingPropertyId`)
      and logic to manage modal title and button text dynamically.
    *   Created a global `window.openEditModal(propertyData)` function
      that populates the modal form with existing property data,
      sets the mode to 'edit', and displays the modal.
    *   Modified the form submission handler to differentiate between
      'add' and 'edit' modes.
        *   For 'edit' mode, it constructs the payload and includes a
          placeholder for calling an `update-property` backend function
          (logged to console, I notified you of the simulation).
        *   Image handling in 'edit' mode is prepared (shows existing
          image, acknowledges new file selection, but actual update
          of image is part of backend work).
    *   Updated the `'hidden.bs.modal'` event listener to correctly
      reset the modal state (mode, title, button text, form fields)
      for subsequent 'add' or 'edit' operations.

3.  **`js/property-details.js`**:
    *   Modified the "Edit Property" link's event listener.
    *   Stores fetched property data in a local variable.
    *   When "Edit Property" is clicked, it calls
      `window.openEditModal()` with the current property's data,
      mapping fields as necessary.

This provides a complete frontend user flow for initiating and simulating the editing of property details. Backend implementation for the actual update is a separate next step.