### PR TITLE
fix: Correct script loading order on property details page

### DIFF
--- a/pages/property-details.html
+++ b/pages/property-details.html
@@ -107,6 +107,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
   <script src="../js/main.js"></script>
   <script type="module" src="../js/i18n.js"></script>
+  <script src="../js/addProperty.js"></script>
   <script type="module" src="../js/property-details.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Ensures `addProperty.js` is loaded before `property-details.js` on the `pages/property-details.html` page.

This resolves a "TypeError: window.openEditModal is not a function" error that occurred when trying to open the "Edit Property" modal. The `openEditModal` function is defined in `addProperty.js` and was being called by `property-details.js` before it was defined due to incorrect script loading order.

The `addProperty.js` script tag has been added to
`pages/property-details.html` and placed before the script tag for `property-details.js`, ensuring `window.openEditModal` is available when needed.