### PR TITLE
fix: Ensure Add/Edit Property modal HTML is on property-details page

### DIFF
--- a/pages/property-details.html
+++ b/pages/property-details.html
@@ -102,6 +102,70 @@
     </div>
   </div>
 
+  <!-- Add Property Modal -->
+  <div class="modal fade" id="addPropertyModal" tabindex="-1" aria-labelledby="addPropertyModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="addPropertyModalLabel" data-i18n="propertiesPage.modal.addTitle">Add New Property</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <form id="addPropertyForm">
+            <div id="addPropertyMessage" class="alert" style="display:none;" role="alert"></div>
+            <input type="hidden" id="propertyIdStore">
+
+            <div class="mb-3">
+              <label for="propertyName" class="form-label" data-i18n="propertiesPage.modal.propertyNameLabel">Property Name</label>
+              <input type="text" class="form-control" id="propertyName" required>
+            </div>
+
+            <div class="mb-3">
+              <label for="propertyAddress" class="form-label" data-i18n="propertiesPage.modal.addressLabel">Address</label>
+              <textarea class="form-control" id="propertyAddress" rows="2" required></textarea>
+            </div>
+
+            <div class="row">
+              <div class="col-md-6 mb-3">
+                <label for="propertyType" class="form-label" data-i18n="propertiesPage.modal.typeLabel">Property Type</label>
+                <select class="form-select" id="propertyType" required>
+                  <option value="" selected disabled data-i18n="propertiesPage.modal.selectTypeOption">Select type...</option>
+                  <option value="House" data-i18n="propertiesPage.modal.typeHouse">House</option>
+                  <option value="Apartment" data-i18n="propertiesPage.modal.typeApartment">Apartment</option>
+                </select>
+              </div>
+              <div class="col-md-6 mb-3">
+                <label for="propertyOccupier" class="form-label" data-i18n="propertiesPage.modal.occupierLabel">Occupier</label>
+                <select class="form-select" id="propertyOccupier" required>
+                  <option value="" selected disabled data-i18n="propertiesPage.modal.selectOccupierOption">Select occupier...</option>
+                  <option value="Owner" data-i18n="propertiesPage.modal.occupierOwner">Owner</option>
+                  <option value="Tenant" data-i18n="propertiesPage.modal.occupierTenant">Tenant</option>
+                </select>
+              </div>
+            </div>
+
+            <div class="mb-3">
+              <label for="propertyDescription" class="form-label" data-i18n="propertiesPage.modal.descriptionLabel">Description</label>
+              <textarea class="form-control" id="propertyDescription" rows="3"></textarea>
+            </div>
+
+            <div class="mb-3">
+              <label for="propertyImageFile" class="form-label" data-i18n="propertiesPage.modal.imageLabel">Property Image</label>
+              <input type="file" class="form-control" id="propertyImageFile" accept="image/*" required>
+              <img id="propertyImagePreview" src="#" alt="Image Preview" class="img-thumbnail mt-2" style="display:none; max-height: 200px;">
+            </div>
+
+          </form>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" data-i18n="propertiesPage.modal.closeButton">Close</button>
+          <button type="submit" form="addPropertyForm" class="btn btn-primary" data-i18n="propertiesPage.modal.saveButton">Save Property</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- End Add Property Modal -->
+
   <script src="../js/supabase-config.js"></script>
   <script type="module" src="../js/supabase-client.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
Copies the HTML structure of the #addPropertyModal (used for both adding and editing properties) from `pages/properties.html` to `pages/property-details.html`.

This resolves JavaScript errors on the property details page where `js/addProperty.js` was unable to find the modal and form elements (#addPropertyModal, #addPropertyForm) it needs to initialize, as these elements were previously missing from this page.

By including the modal HTML on `pages/property-details.html`, the script can now correctly initialize and manage the modal when the "Edit Property" functionality is invoked.