### PR TITLE
fix: Relocate modal footer to be inside the form element

### DIFF
--- a/pages/properties.html
+++ b/pages/properties.html
@@ -119,11 +119,11 @@
               <img id="propertyImagePreview" src="#" alt="Image Preview" class="img-thumbnail mt-2" style="display:none; max-height: 200px;">
             </div>
 
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" data-i18n="propertiesPage.modal.closeButton">Close</button>
+              <button type="submit" class="btn btn-primary" data-i18n="propertiesPage.modal.saveButton">Save Property</button>
+            </div>
           </form>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" data-i18n="propertiesPage.modal.closeButton">Close</button>
-          <button type="submit" form="addPropertyForm" class="btn btn-primary" data-i18n="propertiesPage.modal.saveButton">Save Property</button>
         </div>
       </div>
     </div>

--- a/pages/property-details.html
+++ b/pages/property-details.html
@@ -155,11 +155,11 @@
               <img id="propertyImagePreview" src="#" alt="Image Preview" class="img-thumbnail mt-2" style="display:none; max-height: 200px;">
             </div>
 
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" data-i18n="propertiesPage.modal.closeButton">Close</button>
+              <button type="submit" class="btn btn-primary" data-i18n="propertiesPage.modal.saveButton">Save Property</button>
+            </div>
           </form>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" data-i18n="propertiesPage.modal.closeButton">Close</button>
-          <button type="submit" form="addPropertyForm" class="btn btn-primary" data-i18n="propertiesPage.modal.saveButton">Save Property</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Moves the <div class="modal-footer"> (which contains the close and submit buttons) to be a direct child of the <form id="addPropertyForm"> element in both `pages/properties.html` and
`pages/property-details.html`.

Previously, the modal footer was outside the <form> tags. While the submit button was linked to the form using the `form="addPropertyForm"` attribute, this caused issues with JavaScript reliably finding the submit button using `formElement.querySelector('button[type="submit"]')` because `querySelector` only searches descendant elements. This led to "Submit button not found" errors.

By placing the footer (and thus the submit button) inside the form, the submit button is now a proper descendant. This ensures that JavaScript can consistently find and interact with it during form submission events. The `form` attribute on the submit button was also removed as it became redundant.

This change resolves the "Submit button not found" errors and makes the form structure more semantically correct and robust.