### PR TITLE
Here's the debugging information you requested:

### DIFF
--- a/js/addProperty.js
+++ b/js/addProperty.js
@@ -54,6 +54,8 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function openEditModal(propertyData) {
+    console.log("Data received by openEditModal:", JSON.stringify(propertyData, null, 2)); // ADDED LINE
+
     if (!addPropertyModalInstance || !addPropertyForm) {
       console.error('Add Property Modal or Form not initialized.');
       return;

--- a/js/property-details.js
+++ b/js/property-details.js
@@ -218,11 +218,13 @@ document.addEventListener('DOMContentLoaded', async () => {
                     property_image_url: loadedPropertyDataForEditing.property_image_url,
                     old_image_path: loadedPropertyDataForEditing.property_image_path // Pass the path
                 };
+                console.log("Data being sent to openEditModal:", JSON.stringify(modalData, null, 2));
+
                 if (typeof window.openEditModal === 'function') {
                     window.openEditModal(modalData);
                 } else {
-                    console.error('openEditModal function is not defined. Make sure addProperty.js is loaded.');
-                    alert('Edit functionality is currently unavailable.');
+                    console.error('openEditModal function is not defined. Make sure addProperty.js is loaded and modal HTML is present.');
+                    alert('Edit functionality is currently unavailable. (openEditModal not found)');
                 }
             } else {
                 console.error('Property data not available for editing or not loaded yet.');


### PR DESCRIPTION
I've added some console logs to help trace the data flow for the "Edit Property" modal.

Specifically:
- In `js/property-details.js`, I'm now logging the `modalData` object right before `window.openEditModal()` is called.
- In `js/addProperty.js`, I'm logging the `propertyData` object as soon as it's received by the `openEditModal()` function.

These logs should help us figure out why data might not be appearing correctly in the edit modal fields.