### PR TITLE
fix: Correct element targeting for edit modal and clean up logs

### DIFF
--- a/js/addProperty.js
+++ b/js/addProperty.js
@@ -54,7 +54,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function openEditModal(propertyData) {
-    console.log("Data received by openEditModal:", JSON.stringify(propertyData, null, 2)); // ADDED LINE
+    // console.log("Data received by openEditModal:", JSON.stringify(propertyData, null, 2)); // Kept for potential future debugging if commented out
 
     if (!addPropertyModalInstance || !addPropertyForm) {
       console.error('Add Property Modal or Form not initialized.');
@@ -67,49 +67,43 @@ document.addEventListener('DOMContentLoaded', () => {
       propertyIdStoreInput.value = propertyData.id;
     }
 
-    // Populate form fields with detailed logging
+    // Populate form fields
     const fieldsToPopulate = {
       'propertyName': propertyData.property_name,
       'propertyAddress': propertyData.address,
       'propertyType': propertyData.property_type,
-      'propertyOccupier': propertyData.property_occupier, // Note: property_details.js sends property_occupier from DB
-      'propertyDescription': propertyData.property_details // Note: property_details.js sends property_details from DB
+      'propertyOccupier': propertyData.property_occupier,
+      'propertyDescription': propertyData.property_details
     };
 
     for (const id in fieldsToPopulate) {
-      const element = document.getElementById(id);
-      console.log(`Attempting to populate field with ID: '${id}'. Element found:`, element);
+      const element = addPropertyForm.querySelector(`#${id}`);
       if (element) {
         const valueToSet = fieldsToPopulate[id] || '';
         element.value = valueToSet;
-        console.log(`Set '${id}'.value to:`, valueToSet);
       } else {
-        console.error(`Element with ID '${id}' not found!`);
+        console.error(`Element with ID '${id}' not found during modal population!`);
       }
     }
 
-    // Handle image preview with detailed logging
-    // propertyImagePreview and propertyImageFile are already element references obtained during DOMContentLoaded
-    console.log('Attempting to set image preview. propertyImagePreview element:', propertyImagePreview);
+    // Handle image preview
     if (propertyData.property_image_url && propertyImagePreview) {
       propertyImagePreview.src = propertyData.property_image_url;
       propertyImagePreview.style.display = 'block';
-      console.log('Set propertyImagePreview.src to:', propertyData.property_image_url);
     } else if (propertyImagePreview) {
       propertyImagePreview.src = '#';
       propertyImagePreview.style.display = 'none';
-      console.log('Set propertyImagePreview.src to # (no image or placeholder).');
     } else {
-      console.error('propertyImagePreview element not found (it was null when script initialized)!');
+      // This case means propertyImagePreview itself was null during DOMContentLoaded
+      console.error('propertyImagePreview element reference is missing!');
     }
 
     // Clear the file input
-    console.log('Attempting to clear file input. propertyImageFile element:', propertyImageFile);
     if (propertyImageFile) {
         propertyImageFile.value = '';
-        console.log('Cleared propertyImageFile.value.');
     } else {
-      console.error('propertyImageFile element not found (it was null when script initialized)!');
+       // This case means propertyImageFile itself was null during DOMContentLoaded
+      console.error('propertyImageFile element reference is missing!');
     }
 
     if (modalTitleElement) modalTitleElement.textContent = 'Edit Property';

--- a/js/property-details.js
+++ b/js/property-details.js
@@ -218,7 +218,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     property_image_url: loadedPropertyDataForEditing.property_image_url,
                     old_image_path: loadedPropertyDataForEditing.property_image_path // Pass the path
                 };
-                console.log("Data being sent to openEditModal:", JSON.stringify(modalData, null, 2));
+                // console.log("Data being sent to openEditModal:", JSON.stringify(modalData, null, 2)); // Kept for potential future debugging
 
                 if (typeof window.openEditModal === 'function') {
                     window.openEditModal(modalData);


### PR DESCRIPTION
This commit addresses two main items:
1.  Fixes a bug where "Edit Property" modal fields were not being pre-populated because JavaScript was selecting display elements from the main page instead of input fields within the modal.
    - Modified `js/addProperty.js` in the `openEditModal` function to use `addPropertyForm.querySelector()` when getting elements by ID. This scopes the query to within the modal's form, ensuring the correct input/select/textarea elements are targeted.

2.  Cleans up extensive debugging `console.log` statements that were added to `js/addProperty.js` and `js/property-details.js` to diagnose the modal data flow and field population issues.
    - Most detailed logs have been removed, while essential error messages (e.g., if an element is still not found) are retained.

With these changes, the "Edit Property" modal now correctly pre-populates with existing property data, and the browser console output is cleaner.