### PR TITLE
feat: Make image upload optional when editing existing image

### DIFF
--- a/js/addProperty.js
+++ b/js/addProperty.js
@@ -106,6 +106,17 @@ document.addEventListener('DOMContentLoaded', () => {
       console.error('propertyImageFile element reference is missing!');
     }
 
+    // Dynamically set/remove 'required' attribute for file input in edit mode
+    if (propertyImageFile) { // Ensure propertyImageFile element exists
+      if (propertyData.property_image_url) { // If there's an existing image
+        propertyImageFile.removeAttribute('required');
+        console.log("Edit mode with existing image: 'required' attribute removed from propertyImageFile.");
+      } else { // No existing image, so make it required
+        propertyImageFile.setAttribute('required', 'required');
+        console.log("Edit mode with no existing image: 'required' attribute set for propertyImageFile.");
+      }
+    }
+
     if (modalTitleElement) modalTitleElement.textContent = 'Edit Property';
     if (submitButton) submitButton.textContent = 'Save Changes';
 
@@ -524,6 +535,12 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       if (addPropertyForm) addPropertyForm.reset(); // This will clear propertyImageFile.value
+
+      // Ensure file input is marked as required for 'add' mode.
+      if (propertyImageFile) {
+        propertyImageFile.setAttribute('required', 'required');
+        console.log("Modal hidden, reset to ADD mode: 'required' attribute set for propertyImageFile.");
+      }
 
       if (propertyImagePreview) {
         propertyImagePreview.src = '#';


### PR DESCRIPTION
Modifies the "Edit Property" modal behavior so that you are not forced to re-upload an image if one already exists for the property.

Key changes in `js/addProperty.js`:
- In the `openEditModal` function:
    - If the property being edited already has an image (`propertyData.property_image_url` exists), the `required` attribute is now dynamically removed from the `<input type="file" id="propertyImageFile">`.
    - If the property being edited does not have an image, the `required` attribute is set, ensuring an image is uploaded.
- In the `'hidden.bs.modal'` event listener:
    - The `propertyImageFile` input has its `required` attribute reinstated. This ensures that when the modal is used for "Add New Property" (its default reset state), the image field remains mandatory.

This change improves the user experience when editing properties, allowing you to modify text details without needing to interact with the image uploader if the existing image is to be retained. The image field remains required when adding new properties or when editing a property that does not yet have an image.