### PR TITLE
fix: Correct data collection for edit property payload

### DIFF
--- a/js/addProperty.js
+++ b/js/addProperty.js
@@ -171,11 +171,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
           const updatedPropertyPayload = {
             property_id: propertyId,
-            property_name: document.getElementById('propertyName').value,
-            address: document.getElementById('propertyAddress').value,
-            property_type: document.getElementById('propertyType').value,
-            property_occupier: document.getElementById('propertyOccupier').value,
-            property_details: document.getElementById('propertyDescription').value,
+            property_name: addPropertyForm.querySelector('#propertyName').value,
+            address: addPropertyForm.querySelector('#propertyAddress').value,
+            property_type: addPropertyForm.querySelector('#propertyType').value,
+            property_occupier: addPropertyForm.querySelector('#propertyOccupier').value,
+            property_details: addPropertyForm.querySelector('#propertyDescription').value,
             // property_image_url will be set below
             // old_property_image_to_delete_path will be set below
           };


### PR DESCRIPTION
Resolves an issue where edited values were not being saved because the submit handler in `js/addProperty.js` (edit mode) was sending `undefined` for most fields to the backend.

This was caused by using `document.getElementById()` to retrieve form values, which was incorrectly picking up display elements from the main page instead of the input fields within the modal.

The fix modifies the construction of `updatedPropertyPayload` in the edit mode submit handler to use `addPropertyForm.querySelector('#elementId').value` for each field. This ensures that values are correctly read from the input, select, and textarea elements within the modal form.

With this change, edited text fields and image information are now correctly captured and sent to the `update-property` Edge Function, and changes persist as expected.