### PR TITLE
feat: Add back navigation to property details page

### DIFF
--- a/js/property-details.js
+++ b/js/property-details.js
@@ -11,6 +11,16 @@ document.addEventListener('DOMContentLoaded', async () => {
     const mainContentContainer = document.querySelector('.container.mt-4');
     const ACTIVE_TASK_STATUSES = ['New', 'Inactive', 'In Progress', 'Stuck'];
 
+    const backToPropertiesLinkElement = document.getElementById('backToPropertiesLink');
+
+    if (backToPropertiesLinkElement) {
+        backToPropertiesLinkElement.addEventListener('click', () => {
+            window.location.href = 'properties.html'; // Ensure this path is correct relative to the pages directory
+        });
+    } else {
+        console.error('Back to properties link element not found.');
+    }
+
     function getImagePathFromUrl(imageUrl) {
       if (!imageUrl) return null;
       try {

--- a/pages/property-details.html
+++ b/pages/property-details.html
@@ -49,7 +49,10 @@
 
     <div class="container mt-4">
       <div class="d-flex justify-content-between align-items-center mb-3">
-        <h1 id="propertyName" class="mb-0">[Property Name Loading...]</h1>
+        <div class="d-flex align-items-center">
+          <span id="backToPropertiesLink" class="back-navigation-chevron me-2"><i class="fas fa-chevron-left"></i></span>
+          <h1 id="propertyName" class="mb-0">[Property Name Loading...]</h1>
+        </div>
         <div class="dropdown">
           <a class="dropdown-toggle dropdown-toggle-no-caret" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
             <i class="fas fa-ellipsis-v fa-2x"></i>


### PR DESCRIPTION
This commit introduces a back navigation feature on the property details page.

A chevron icon has been added to the left of the property name. Clicking this icon navigates you back to the main properties listing page (`properties.html`).

Changes include:
- Modified `pages/property-details.html` to include the chevron icon and adjust the layout.
- Updated `js/property-details.js` to handle the click event on the new icon and perform the navigation.