### PR TITLE
style: Improve clickable area and spacing for back navigation icon

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -442,3 +442,15 @@ The original request was "stroke of all borders", not necessarily hover/active s
     width: 80%;
   }
 }
+
+.back-button-area {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  background-color: transparent;
+  text-decoration: none; /* To remove underline from <a> tag */
+  color: inherit; /* To ensure icon inherits color, or set a specific color */
+  margin-right: 8px; /* Provides spacing to the right, adjust as needed */
+}

--- a/pages/property-details.html
+++ b/pages/property-details.html
@@ -50,7 +50,9 @@
     <div class="container mt-4">
       <div class="d-flex justify-content-between align-items-center mb-3">
         <div class="d-flex align-items-center">
-          <span id="backToPropertiesLink" class="back-navigation-chevron me-2"><i class="fas fa-chevron-left"></i></span>
+          <a href="#" id="backToPropertiesLink" class="back-button-area">
+            <span class="back-navigation-chevron"><i class="fas fa-chevron-left"></i></span>
+          </a>
           <h1 id="propertyName" class="mb-0">[Property Name Loading...]</h1>
         </div>
         <div class="dropdown">


### PR DESCRIPTION
This commit refines the back navigation icon on the property details page.

The chevron icon is now wrapped in an anchor tag styled as an icon button with a 48x48px clickable area and a transparent background. This provides a larger, more accessible tap target and improves spacing between the icon and the property name.

Changes include:
- Modified `pages/property-details.html` to wrap the icon in an `<a>` tag.
- Added CSS to `css/style.css` for the new `back-button-area` class, defining its size, transparent background, and spacing.
- Adjusted HTML to use the new CSS for spacing.