### PR TITLE
fix: Improve 'no properties' message on properties page

### DIFF
--- a/js/lazy-load-properties.js
+++ b/js/lazy-load-properties.js
@@ -15,10 +15,15 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
     if (properties.length === 0 && initialOffset === 0) {
-        const noPropertiesMessage = (typeof i18next !== 'undefined' && typeof i18next.t === 'function') ?
-                                    i18next.t('propertiesPage.noProperties') :
-                                    'No properties found for your account.';
-        propertiesContainer.innerHTML = `<div class="col-12"><p>${noPropertiesMessage}</p></div>`;
+        let noPropertiesMessageText = 'You currently have no properties. Click \'Add Property\' to create one!'; // Default fallback
+        if (typeof i18next !== 'undefined' && typeof i18next.t === 'function') {
+            const translated = i18next.t('propertiesPage.noProperties');
+            // Check if translation is different from key and not undefined/null
+            if (translated && translated !== 'propertiesPage.noProperties') {
+                noPropertiesMessageText = translated;
+            }
+        }
+        propertiesContainer.innerHTML = `<div class="col-12"><p>${noPropertiesMessageText}</p></div>`;
         allPropertiesLoaded = true; // No properties to load
         return;
     }

--- a/locales/de.json
+++ b/locales/de.json
@@ -70,6 +70,7 @@
     "searchPlaceholder": "Immobilien suchen...",
     "filterButton": "Filter",
     "addPropertyButton": "+ Immobilie hinzufügen",
+    "noProperties": "Ihnen sind derzeit keine Immobilien zugewiesen. Klicken Sie auf 'Immobilie hinzufügen', um loszulegen!",
     "card": {
       "tasksLabel": "Aufgaben",
       "noActiveTasks": "Keine aktiven Aufgaben",

--- a/locales/en.json
+++ b/locales/en.json
@@ -70,6 +70,7 @@
     "searchPlaceholder": "Search properties...",
     "filterButton": "Filter",
     "addPropertyButton": "+ Add Property",
+    "noProperties": "You currently have no properties assigned. Click 'Add Property' to get started!",
     "card": {
       "tasksLabel": "Tasks",
       "noActiveTasks": "No Active Tasks",


### PR DESCRIPTION
Replaces an issue where "undefined" could be displayed if you had no properties.

Changes:
- Updated `js/lazy-load-properties.js` to provide a more robust default fallback message if the i18next translation is missing.
- Added the translation key `propertiesPage.noProperties` to both `locales/en.json` and `locales/de.json` with a user-friendly hint text.