### PR TITLE
style: Increase horizontal padding on property details page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -454,3 +454,9 @@ The original request was "stroke of all borders", not necessarily hover/active s
   color: inherit; /* To ensure icon inherits color, or set a specific color */
   margin-right: 8px; /* Provides spacing to the right, adjust as needed */
 }
+
+/* Custom padding for property-details page container */
+.property-details-container-padding {
+  padding-left: 2.25rem; /* Original 0.75rem * 3 */
+  padding-right: 2.25rem; /* Original 0.75rem * 3 */
+}

--- a/pages/property-details.html
+++ b/pages/property-details.html
@@ -47,7 +47,7 @@
       </div>
     </div>
 
-    <div class="container mt-4">
+    <div class="container mt-4 property-details-container-padding">
       <div class="d-flex justify-content-between align-items-center mb-3">
         <div class="d-flex align-items-center">
           <a href="#" id="backToPropertiesLink" class="back-button-area">


### PR DESCRIPTION
Triples the left and right padding for the main container on the property-details.html page. This provides more spacing between the page content and the side edges of the viewport.

Changes:
- Added custom class `property-details-container-padding` to the main container in `pages/property-details.html`.
- Defined this class in `css/style.css` to apply `2.25rem` padding on the left and right.