### PR TITLE
feat: Implement Edit Profile functionality on Account page

### DIFF
--- a/js/account-details.js
+++ b/js/account-details.js
@@ -1,94 +1,240 @@
 document.addEventListener('DOMContentLoaded', async () => {
+    // Main page elements
     const fullNameElement = document.getElementById('fullName');
     const emailAddressElement = document.getElementById('emailAddress');
     const phoneNumberElement = document.getElementById('phoneNumber');
-    const languageSelectorElement = document.getElementById('languageSelector');
+    const languageDisplayElement = document.getElementById('languageDisplay');
 
-    if (!fullNameElement || !emailAddressElement || !phoneNumberElement || !languageSelectorElement) {
-        console.error('One or more profile elements not found in account.html');
+    // Modal elements
+    const editProfileModalElement = document.getElementById('editProfileModal');
+    const editProfileForm = document.getElementById('editProfileForm');
+    const modalFirstNameElement = document.getElementById('modalFirstName');
+    const modalLastNameElement = document.getElementById('modalLastName');
+    const modalEmailAddressElement = document.getElementById('modalEmailAddress');
+    const modalPhoneNumberElement = document.getElementById('modalPhoneNumber');
+    const modalLanguageSelectorElement = document.getElementById('modalLanguageSelector');
+    const saveProfileChangesButton = document.getElementById('saveProfileChanges');
+    const editProfileButton = document.getElementById('editProfileButton');
+    const editProfileMessageElement = document.getElementById('editProfileMessage');
+
+    if (!fullNameElement || !emailAddressElement || !phoneNumberElement || !languageDisplayElement ||
+        !editProfileModalElement || !editProfileForm || !modalFirstNameElement || !modalLastNameElement ||
+        !modalEmailAddressElement || !modalPhoneNumberElement || !modalLanguageSelectorElement ||
+        !saveProfileChangesButton || !editProfileButton || !editProfileMessageElement) {
+        console.error('One or more profile or modal elements not found in account.html');
         return;
     }
 
-    if (!window._supabase) {
-        console.error('Supabase client is not available.');
-        // Potentially display a message to the user in an alert or a designated div
-        return;
-    }
-
-    try {
-        const { data: { user }, error: userError } = await window._supabase.auth.getUser();
-
-        if (userError) {
-            console.error('Error fetching user:', userError);
-            // Display error to user if appropriate
+    window.loadAndDisplayAccountDetails = async function() {
+        if (!window._supabase) {
+            console.error('Supabase client is not available.');
+            fullNameElement.value = 'Error: Supabase client not found';
+            emailAddressElement.value = 'Error: Supabase client not found';
+            phoneNumberElement.value = 'Error: Supabase client not found';
+            languageDisplayElement.value = 'Error: Supabase client not found';
             return;
         }
 
-        if (!user) {
-            console.log('No user logged in.');
-            // Redirect to login or display message
-            // For now, just ensure fields are empty or show placeholder text
-            fullNameElement.value = 'N/A';
-            emailAddressElement.value = 'N/A';
-            phoneNumberElement.value = 'N/A';
-            return;
-        }
+        try {
+            const { data: { user }, error: userError } = await window._supabase.auth.getUser();
 
-        // User is available, fetch their profile
-        const { data: profile, error: profileError } = await window._supabase
-            .from('profiles')
-            .select('first_name, last_name, email, phone_number, preferred_ui_language')
-            .eq('id', user.id)
-            .single();
+            if (userError) {
+                console.error('Error fetching user:', userError);
+                fullNameElement.value = 'Error fetching user';
+                emailAddressElement.value = 'Error fetching user';
+                phoneNumberElement.value = 'Error fetching user';
+                languageDisplayElement.value = 'Error fetching user';
+                return;
+            }
 
-        if (profileError) {
-            console.error('Error fetching profile:', profileError);
-            // Display error to user, perhaps keeping dummy data or clearing fields
-            fullNameElement.value = 'Error loading data';
-            emailAddressElement.value = 'Error loading data';
-            phoneNumberElement.value = 'Error loading data';
-            return;
-        }
+            if (!user) {
+                console.log('No user logged in.');
+                fullNameElement.value = 'N/A';
+                emailAddressElement.value = 'N/A';
+                phoneNumberElement.value = 'N/A';
+                languageDisplayElement.value = 'N/A';
+                return;
+            }
 
-        if (profile) {
-            // Populate Full Name
-            const firstName = profile.first_name || '';
-            const lastName = profile.last_name || '';
-            fullNameElement.value = `${firstName} ${lastName}`.trim() || 'Name not set';
+            const { data: profile, error: profileError } = await window._supabase
+                .from('profiles')
+                .select('first_name, last_name, email, phone_number, preferred_ui_language')
+                .eq('id', user.id)
+                .single();
 
-            // Populate Email Address
-            emailAddressElement.value = profile.email || 'Email not set';
+            if (profileError) {
+                console.error('Error fetching profile:', profileError);
+                fullNameElement.value = 'Error loading profile data';
+                emailAddressElement.value = 'Error loading profile data';
+                phoneNumberElement.value = 'Error loading profile data';
+                languageDisplayElement.value = 'Error loading profile data';
+                return;
+            }
 
-            // Populate Phone Number
-            if (profile.phone_number && profile.phone_number.trim() !== '') {
-                phoneNumberElement.value = profile.phone_number;
+            if (profile) {
+                const firstName = profile.first_name || '';
+                const lastName = profile.last_name || '';
+                fullNameElement.value = `${firstName} ${lastName}`.trim() || 'Name not set';
+                emailAddressElement.value = profile.email || 'Email not set';
+
+                if (profile.phone_number && profile.phone_number.trim() !== '') {
+                    phoneNumberElement.value = profile.phone_number;
+                } else {
+                    phoneNumberElement.value = 'Not provided';
+                }
+
+                if (languageDisplayElement) {
+                    if (profile.preferred_ui_language) {
+                        let langFullName = 'Unknown';
+                        if (profile.preferred_ui_language === 'en') {
+                            langFullName = 'English';
+                        } else if (profile.preferred_ui_language === 'de') {
+                            langFullName = 'German';
+                        } else {
+                            langFullName = profile.preferred_ui_language;
+                        }
+                        languageDisplayElement.value = langFullName;
+                    } else {
+                        languageDisplayElement.value = 'Not set';
+                    }
+                }
             } else {
-                phoneNumberElement.value = 'Not provided'; // Hint text
+                console.log('No profile found for the user.');
+                fullNameElement.value = 'Profile not found';
+                emailAddressElement.value = 'Profile not found';
+                phoneNumberElement.value = 'Profile not found';
+                languageDisplayElement.value = 'Profile not found';
             }
-
-            // Set Language Selector
-            // The existing i18next setup might handle this, but we can set it based on fetched profile
-            // This ensures the selector matches the profile data if i18next hasn't initialized with it yet
-            if (profile.preferred_ui_language) {
-                languageSelectorElement.value = profile.preferred_ui_language;
-            }
-            // The existing event listener on languageSelector should still handle changes
-            // and i18next's initial language setting. This just aligns the selector
-            // if data is fetched before i18next fully syncs the display.
-
-        } else {
-            console.log('No profile found for the user.');
-            // Clear fields or show 'Not available'
-            fullNameElement.value = 'Profile not found';
-            emailAddressElement.value = 'Profile not found';
-            phoneNumberElement.value = 'Profile not found';
+        } catch (error) {
+            console.error('An unexpected error occurred in loadAndDisplayAccountDetails:', error);
+            fullNameElement.value = 'Failed to load profile';
+            emailAddressElement.value = 'Failed to load profile';
+            phoneNumberElement.value = 'Failed to load profile';
+            languageDisplayElement.value = 'Failed to load profile';
         }
+    };
 
-    } catch (error) {
-        console.error('An unexpected error occurred:', error);
-        // Display a generic error message
-        fullNameElement.value = 'Failed to load profile';
-        emailAddressElement.value = 'Failed to load profile';
-        phoneNumberElement.value = 'Failed to load profile';
+    await window.loadAndDisplayAccountDetails(); // Initial load
+
+    // Populate Modal on Show Event
+    if (editProfileModalElement && editProfileButton) {
+        // const modalInstance = new bootstrap.Modal(editProfileModalElement); // Not strictly needed if only using button's data-bs-toggle
+
+        editProfileButton.addEventListener('click', async () => {
+            editProfileMessageElement.style.display = 'none'; // Clear previous messages
+            try {
+                const { data: { user } , error: userErr } = await window._supabase.auth.getUser();
+                if (userErr || !user) {
+                    editProfileMessageElement.textContent = 'User not logged in or session expired.';
+                    editProfileMessageElement.className = 'alert alert-danger';
+                    editProfileMessageElement.style.display = 'block';
+                    console.error('Error fetching user for modal:', userErr);
+                    // Consider not opening the modal or disabling save button if this happens
+                    // For now, we allow modal to open but fields might be empty or save will fail
+                    return;
+                }
+
+                const { data: profile, error: profileErr } = await window._supabase
+                    .from('profiles')
+                    .select('first_name, last_name, email, phone_number, preferred_ui_language')
+                    .eq('id', user.id)
+                    .single();
+
+                if (profileErr || !profile) {
+                    editProfileMessageElement.textContent = 'Error fetching profile for editing.';
+                    editProfileMessageElement.className = 'alert alert-danger';
+                    editProfileMessageElement.style.display = 'block';
+                    console.error('Error fetching profile for modal:', profileErr);
+                     // Populate with whatever is available or defaults
+                    modalFirstNameElement.value = '';
+                    modalLastNameElement.value = '';
+                    modalEmailAddressElement.value = user.email || ''; // Email from auth user as fallback
+                    modalPhoneNumberElement.value = '';
+                    modalLanguageSelectorElement.value = 'en';
+                    return; // Keep modal open but show error.
+                }
+
+                // Populate modal fields
+                modalFirstNameElement.value = profile.first_name || '';
+                modalLastNameElement.value = profile.last_name || '';
+                modalEmailAddressElement.value = profile.email || ''; // Should be readonly, but populate anyway
+                modalPhoneNumberElement.value = profile.phone_number || '';
+                modalLanguageSelectorElement.value = profile.preferred_ui_language || 'en';
+
+            } catch (e) {
+                editProfileMessageElement.textContent = 'An unexpected error occurred preparing the form.';
+                editProfileMessageElement.className = 'alert alert-danger';
+                editProfileMessageElement.style.display = 'block';
+                console.error('Error in editProfileButton click listener:', e);
+            }
+        });
+    }
+
+    // Handle Save Changes
+    if (saveProfileChangesButton && editProfileForm) {
+        saveProfileChangesButton.addEventListener('click', async () => {
+            const firstName = modalFirstNameElement.value.trim();
+            const lastName = modalLastNameElement.value.trim();
+            const phoneNumber = modalPhoneNumberElement.value.trim();
+            const preferredLanguage = modalLanguageSelectorElement.value;
+
+            if (!firstName || !lastName) {
+                editProfileMessageElement.textContent = 'First Name and Last Name are required.';
+                editProfileMessageElement.className = 'alert alert-danger';
+                editProfileMessageElement.style.display = 'block';
+                return;
+            }
+
+            try {
+                const { data: { user }, error: getUserError } = await window._supabase.auth.getUser();
+                if (getUserError || !user) {
+                    editProfileMessageElement.textContent = 'User session expired. Please log in again.';
+                    editProfileMessageElement.className = 'alert alert-danger';
+                    editProfileMessageElement.style.display = 'block';
+                    return;
+                }
+
+                const updates = {
+                    first_name: firstName,
+                    last_name: lastName,
+                    phone_number: phoneNumber || null,
+                    preferred_ui_language: preferredLanguage,
+                    updated_at: new Date()
+                };
+
+                const { error: updateError } = await window._supabase
+                    .from('profiles')
+                    .update(updates)
+                    .eq('id', user.id);
+
+                if (updateError) {
+                    console.error('Error updating profile:', updateError);
+                    editProfileMessageElement.textContent = `Error updating profile: ${updateError.message}`;
+                    editProfileMessageElement.className = 'alert alert-danger';
+                    editProfileMessageElement.style.display = 'block';
+                } else {
+                    editProfileMessageElement.textContent = 'Profile updated successfully!';
+                    editProfileMessageElement.className = 'alert alert-success';
+                    editProfileMessageElement.style.display = 'block';
+
+                    if (window.loadAndDisplayAccountDetails) {
+                        await window.loadAndDisplayAccountDetails();
+                    }
+
+                    setTimeout(() => {
+                        const modalInstance = bootstrap.Modal.getInstance(editProfileModalElement);
+                        if (modalInstance) {
+                           modalInstance.hide();
+                        }
+                        editProfileMessageElement.style.display = 'none';
+                    }, 1500);
+                }
+            } catch (e) {
+                console.error('Error saving profile changes:', e);
+                editProfileMessageElement.textContent = 'An unexpected error occurred while saving.';
+                editProfileMessageElement.className = 'alert alert-danger';
+                editProfileMessageElement.style.display = 'block';
+            }
+        });
     }
 });

--- a/pages/account.html
+++ b/pages/account.html
@@ -77,13 +77,10 @@
                   <input type="tel" class="form-control" id="phoneNumber" value="+1 234 567 8900 (Dummy Data)" readonly>
                 </div>
                 <div class="mb-3">
-                  <label for="languageSelector" class="form-label" data-i18n="accountPage.profile.languageLabel">Language</label>
-                  <select class="form-select" id="languageSelector">
-                    <option value="en" data-i18n="accountPage.profile.langEn">English</option>
-                    <option value="de" data-i18n="accountPage.profile.langDe">German</option>
-                  </select>
+                  <label for="languageDisplay" class="form-label" data-i18n="accountPage.profile.languageLabel">Language</label>
+                  <input type="text" class="form-control" id="languageDisplay" readonly>
                 </div>
-                <button type="button" class="btn btn-primary" data-i18n="accountPage.profile.editButton">Edit Profile</button> 
+                <button type="button" class="btn btn-primary" id="editProfileButton" data-bs-toggle="modal" data-bs-target="#editProfileModal" data-i18n="accountPage.profile.editButton">Edit Profile</button>
                 <!-- For now, this button won't do anything -->
               </form>
             </div>
@@ -221,6 +218,54 @@
     </div>
   </div>
 
+<!-- Edit Profile Modal -->
+<div class="modal fade" id="editProfileModal" tabindex="-1" aria-labelledby="editProfileModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="editProfileModalLabel">Edit Profile Information</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="editProfileForm">
+          <!-- Alert for messages -->
+          <div id="editProfileMessage" class="alert" style="display:none;" role="alert"></div>
+
+          <div class="mb-3">
+            <label for="modalFirstName" class="form-label">First Name</label>
+            <input type="text" class="form-control" id="modalFirstName" required>
+          </div>
+          <div class="mb-3">
+            <label for="modalLastName" class="form-label">Last Name</label>
+            <input type="text" class="form-control" id="modalLastName" required>
+          </div>
+          <div class="mb-3">
+            <label for="modalEmailAddress" class="form-label">Email Address</label>
+            <input type="email" class="form-control" id="modalEmailAddress" readonly>
+          </div>
+          <div class="mb-3">
+            <label for="modalPhoneNumber" class="form-label">Phone Number</label>
+            <input type="tel" class="form-control" id="modalPhoneNumber">
+            <small class="form-text text-muted">Enter phone number or leave blank.</small>
+          </div>
+          <div class="mb-3">
+            <label for="modalLanguageSelector" class="form-label">Language</label>
+            <select class="form-select" id="modalLanguageSelector">
+              <option value="en">English</option>
+              <option value="de">German</option>
+            </select>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary" id="saveProfileChanges">Save Changes</button>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- End Edit Profile Modal -->
+
   <script src="../js/supabase-config.js"></script>
   <script type="module" src="../js/supabase-client.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
@@ -229,6 +274,7 @@
   <script src="../js/notifications.js"></script> <!-- This is the new line -->
   <script type="module" src="../js/i18n.js"></script>
   <script src="../js/account-details.js"></script> <!-- Add this line -->
+<!--
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     const languageSelector = document.getElementById('languageSelector');
@@ -250,5 +296,6 @@
     }
   });
 </script>
+-->
 </body>
 </html>


### PR DESCRIPTION
This commit adds the ability for you to edit your profile information (Full Name, Phone Number, Language) on the Account page (`pages/account.html`) using a Bootstrap modal.

Key changes:
1.  **Read-Only Display:**
    *   The main account page now displays your language as a
      read-only text field (e.g., "English") instead of a dropdown.
    *   Other profile fields (Full Name, Email, Phone) remain read-only
      by default.

2.  **Edit Profile Modal:**
    *   Added an "Edit Profile" modal triggered by the "Edit Profile" button.
    *   The modal contains separate input fields for "First Name" and
      "Last Name", a read-only "Email Address" field, an editable
      "Phone Number" field, and a "Language" select dropdown.

3.  **JavaScript Updates (`js/account-details.js`):**
    *   Refactored the initial data loading logic into a reusable function
      `loadAndDisplayAccountDetails` for populating both the main page
      and the modal.
    *   Implemented logic to populate the modal with your current
      profile data when the "Edit Profile" button is clicked.
    *   Added functionality to the "Save Changes" button in the modal to:
        - Validate input (First Name and Last Name are required).
        - Update the `first_name`, `last_name`, `phone_number`, and
          `preferred_ui_language` fields in the Supabase `profiles` table.
        - Refresh the read-only information on the main account page
          upon successful update.
        - Display success or error messages within the modal.
        - Close the modal on successful save.

4.  **HTML Structure:**
    *   Modified `pages/account.html` to include the modal structure
      and change the language display field.
    *   Commented out the old inline script for language selection on the
      main page as this is now handled differently.