### PR TITLE
Update verification code length from 6 to 8 digits.

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
         <div class="modal-body">
           <p data-i18n="sixDigitCodeModal.description">For your security, please enter the 6-digit code.</p>
           <div class="form-floating mb-3">
-            <input type="tel" class="form-control" id="sixDigitCodeInput" placeholder="123456" maxlength="6" pattern="[0-9]{6}">
+            <input type="tel" class="form-control" id="sixDigitCodeInput" placeholder="12345678" maxlength="8" pattern="[0-9]{8}">
             <label for="sixDigitCodeInput" data-i18n="sixDigitCodeModal.inputLabel">6-digit Code</label>
           </div>
           <div id="sixDigitCodeMessage" class="mt-2"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -157,8 +157,8 @@ document.addEventListener('DOMContentLoaded', function () {
             firstNameDebugMessage = " (Debug: first_name '" + data.user.user_metadata.first_name + "' seen in user_metadata)";
           }
 
-          // Generate 6-digit code and update profile
-          const generatedCode = Math.floor(100000 + Math.random() * 900000).toString();
+          // Generate 8-digit code and update profile
+          const generatedCode = Math.floor(10000000 + Math.random() * 90000000).toString();
           const userId = data.user.id;
 
           try {
@@ -320,7 +320,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 // A better approach for complex scenarios: define handler outside and manage it.
                 const handleSubmitCode = async () => {
                   const enteredCode = sixDigitCodeInput ? sixDigitCodeInput.value : '';
-                  if (!enteredCode || !/^\d{6}$/.test(enteredCode)) {
+                  if (!enteredCode || !/^\d{8}$/.test(enteredCode)) {
                     if (sixDigitCodeMessage) {
                       sixDigitCodeMessage.textContent = i18next.t('sixDigitCodeModal.invalidInput'); // Create i18n key
                       sixDigitCodeMessage.className = 'alert alert-warning';

--- a/locales/en.json
+++ b/locales/en.json
@@ -286,11 +286,11 @@
   },
   "sixDigitCodeModal": {
     "title": "Enter Verification Code",
-    "description": "For your security, please enter your 6-digit verification code.",
-    "inputLabel": "6-Digit Code",
+    "description": "For your security, please enter your 8-digit verification code.",
+    "inputLabel": "8-Digit Code",
     "verifyButton": "Verify Code",
     "closeButton": "Close",
-    "invalidInput": "Please enter a valid 6-digit numerical code.",
+    "invalidInput": "Please enter a valid 8-digit numerical code.",
     "updateError": "Failed to update verification status. Please try again.",
     "success": "Verification successful! Redirecting...",
     "incorrectCode": "Incorrect code. Please try again."


### PR DESCRIPTION
This commit modifies the post-first-login verification code feature to use an 8-digit numerical code instead of a 6-digit one.

Changes include:
- Updated `js/main.js` in the sign-up process to generate a random 8-digit numerical code.
- Modified `index.html` to update the code input modal:
  - Changed `maxlength` of the input field to 8.
  - Updated the `pattern` attribute to `[0-9]{8}`.
  - Updated the placeholder text to suggest 8 digits.
- Adjusted the code validation logic in `js/main.js` (sign-in process) to check for an 8-digit numerical code.
- Updated relevant i18n translations in `locales/en.json` (e.g., modal description, input label, invalid input messages) to refer to "8-digit code" instead of "6-digit code".