### PR TITLE
Fix: Correct 8-digit code comparison logic.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -328,7 +328,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     return;
                   }
 
-                  if (enteredCode === profile.verification_code) {
+                  if (enteredCode.trim() === String(profile.verification_code).trim()) {
                     const { error: updateError } = await window._supabase
                       .from('profiles')
                       .update({ is_verified_by_code: true })


### PR DESCRIPTION
This commit resolves an issue where the 8-digit verification code was incorrectly being reported as wrong even when the correct code was entered.

The fix involves:
- Modifying the comparison in `js/main.js` within the `handleSubmitCode` function.
- Ensuring both the entered code and the stored code are compared as strings using `String(profile.verification_code)`.
- Trimming whitespace from both the entered code (`enteredCode.trim()`) and the string version of the stored code (`String(profile.verification_code).trim()`) before comparison.

This makes the comparison robust against type mismatches (string vs. number) and accidental leading/trailing whitespace. Diagnostic console logs that were temporarily added to debug this issue have been removed.