### PR TITLE
I've added a diagnostic log for the create-property response.

### DIFF
--- a/js/addProperty.js
+++ b/js/addProperty.js
@@ -450,6 +450,7 @@ document.addEventListener('DOMContentLoaded', () => {
           throw new Error(functionResponseData.error);
         }
         
+        console.log('Response from create-property Edge Function:', JSON.stringify(functionResponseData, null, 2));
         const newPropertyId = functionResponseData.property.id;
 
         // QR Code Generation and Upload (Conditional)


### PR DESCRIPTION
This commit adds a `console.log` statement in `js/addProperty.js` to print the full response received from the 'create-property' Edge Function. This is a debugging step to help investigate a "Cannot read properties of undefined (reading 'id')" error that occurs during new property creation, specifically before QR code generation.

The underlying error is not yet fixed with this commit. The log is intended to help identify the correct way to access the new property's ID from the Edge Function's response.