### PR TITLE
Fix: Correctly extract new property ID from Edge Function response.

### DIFF
--- a/js/addProperty.js
+++ b/js/addProperty.js
@@ -450,8 +450,7 @@ document.addEventListener('DOMContentLoaded', () => {
           throw new Error(functionResponseData.error);
         }
         
-        console.log('Response from create-property Edge Function:', JSON.stringify(functionResponseData, null, 2));
-        const newPropertyId = functionResponseData.property.id;
+        const newPropertyId = functionResponseData.data.id;
 
         // QR Code Generation and Upload (Conditional)
         if (generateQr) {


### PR DESCRIPTION
This commit resolves the "Cannot read properties of undefined (reading 'id')" error that occurred during new property creation in `js/addProperty.js`.

The 'create-property' Edge Function returns the new property's data nested under a 'data' key (e.g., `{ data: { id: '...' } }`). The code was previously attempting to access it via a 'property' key.

The fix updates the ID extraction to use `functionResponseData.data.id` instead of `functionResponseData.property.id`.

Diagnostic console.log statements added temporarily to identify this issue have also been removed.