### PR TITLE
Fix: Correct script load order for qrious library.

### DIFF
--- a/pages/properties.html
+++ b/pages/properties.html
@@ -161,11 +161,11 @@
   <script src="../js/supabase-config.js"></script>
   <script type="module" src="../js/supabase-client.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/qrious/dist/qrious.min.js"></script>
   <script type="module" src="../js/dashboard_check.js"></script> 
   <script src="../js/main.js"></script>
   <script type="module" src="../js/i18n.js"></script>
   <script src="../js/lazy-load-properties.js"></script>
   <script src="../js/addProperty.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/qrious/dist/qrious.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This commit resolves a "ReferenceError: qrious is not defined" that occurred in `js/addProperty.js` during QR code generation.

The error was caused by the `qrious.min.js` CDN script being loaded after `addProperty.js` in `pages/properties.html`. The order has been corrected to ensure `qrious.min.js` is loaded before any custom scripts that depend on it.