### PR TITLE
Fix: Add defer attribute to custom scripts to ensure qrious loads.

### DIFF
--- a/pages/properties.html
+++ b/pages/properties.html
@@ -163,9 +163,9 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/qrious/dist/qrious.min.js"></script>
   <script type="module" src="../js/dashboard_check.js"></script> 
-  <script src="../js/main.js"></script>
+  <script src="../js/main.js" defer></script>
   <script type="module" src="../js/i18n.js"></script>
-  <script src="../js/lazy-load-properties.js"></script>
-  <script src="../js/addProperty.js"></script>
+  <script src="../js/lazy-load-properties.js" defer></script>
+  <script src="../js/addProperty.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
This commit addresses a persistent "ReferenceError: qrious is not defined" in `addProperty.js` on the properties page.

The `defer` attribute has been added to the script tags for `main.js`, `lazy-load-properties.js`, and `addProperty.js` in `pages/properties.html`. This ensures these scripts execute in order after the HTML document is fully parsed, and after preceding standard scripts like `qrious.min.js` (loaded from CDN) have had a chance to load and define their global objects.

This change aims to resolve the script execution timing issue that likely caused `qrious` to be undefined when `addProperty.js` was invoked.