### PR TITLE
Fix: Ensure qrious library loads before addProperty.js

### DIFF
--- a/pages/properties.html
+++ b/pages/properties.html
@@ -161,7 +161,7 @@
   <script src="../js/supabase-config.js"></script>
   <script type="module" src="../js/supabase-client.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/qrious/dist/qrious.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/qrious/dist/qrious.min.js" defer></script>
   <script type="module" src="../js/dashboard_check.js"></script> 
   <script src="../js/main.js" defer></script>
   <script type="module" src="../js/i18n.js"></script>


### PR DESCRIPTION
I've added the `defer` attribute to the `qrious.min.js` script tag in `pages/properties.html`. This resolves a `ReferenceError: qrious is not defined` that occurred during QR code generation because `addProperty.js` was attempting to use `qrious` before it had fully loaded. By deferring both scripts and maintaining their order in the HTML, `qrious` is now guaranteed to load and execute before `addProperty.js`.