### PR TITLE
Fix: Correct qrious library loading order in properties.html

### DIFF
--- a/pages/properties.html
+++ b/pages/properties.html
@@ -161,11 +161,11 @@
   <script src="../js/supabase-config.js"></script>
   <script type="module" src="../js/supabase-client.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/qrious/dist/qrious.min.js" defer></script>
   <script type="module" src="../js/dashboard_check.js"></script> 
   <script src="../js/main.js" defer></script>
   <script type="module" src="../js/i18n.js"></script>
   <script src="../js/lazy-load-properties.js" defer></script>
-  <script src="../js/addProperty.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/qrious/dist/qrious.min.js"></script>
+  <script src="../js/addProperty.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Ensures `qrious.min.js` is loaded and executed before `addProperty.js` by:
1. Placing the script tag for `qrious.min.js` (without `defer`) immediately before the script tag for `addProperty.js` (without `defer`).

This resolves a `ReferenceError: qrious is not defined` that occurred during QR code generation because `addProperty.js` was attempting to use the `qrious` object before it was available. The previous attempt using only `defer` was not sufficient to guarantee the correct loading order in all cases.