### PR TITLE
Fix: Change CDN for qrious library to resolve loading issues

### DIFF
--- a/pages/properties.html
+++ b/pages/properties.html
@@ -165,7 +165,7 @@
   <script src="../js/main.js" defer></script>
   <script type="module" src="../js/i18n.js"></script>
   <script src="../js/lazy-load-properties.js" defer></script>
-  <script src="https://cdn.jsdelivr.net/npm/qrious/dist/qrious.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/qrious/4.0.2/qrious.min.js" defer></script>
   <script src="../js/addProperty.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
I changed the source of the `qrious.min.js` library in `pages/properties.html` from jsdelivr to cdnjs (`https://cdnjs.cloudflare.com/ajax/libs/qrious/4.0.2/qrious.min.js`).

This resolves a persistent `ReferenceError: qrious is not defined` that occurred during QR code generation. The retry mechanism in `addProperty.js` confirmed that the library was not loading from the previous CDN, and switching to cdnjs has proven effective.

The `addProperty.js` script still contains the retry logic for `qrious` loading, which adds robustness, although the primary issue appears to have been CDN-related.