### PR TITLE
Fix: Make qrious.min.js and addProperty.js blocking scripts

### DIFF
--- a/pages/properties.html
+++ b/pages/properties.html
@@ -165,7 +165,7 @@
   <script src="../js/main.js" defer></script>
   <script type="module" src="../js/i18n.js"></script>
   <script src="../js/lazy-load-properties.js" defer></script>
-  <script src="../js/vendor/qrious.min.js" defer></script>
-  <script src="../js/addProperty.js" defer></script>
+  <script src="../js/vendor/qrious.min.js"></script>
+  <script src="../js/addProperty.js"></script>
 </body>
 </html>


### PR DESCRIPTION
I removed the `defer` attribute from the script tags for both `js/vendor/qrious.min.js` (served locally) and `js/addProperty.js` in `pages/properties.html`.

This ensures that `qrious.min.js` is loaded and executed, followed by `addProperty.js`, in a blocking manner before the browser continues parsing the rest of the page or firing `DOMContentLoaded` for other scripts. This approach resolved a persistent `ReferenceError: qrious is not defined` where `qrious` failed to load/execute correctly with `defer` attributes or via CDNs.

The `addProperty.js` script still contains its retry/waiting logic for `qrious`, providing an extra layer of safety, though making the scripts blocking appears to be the primary fix for this environment.