### PR TITLE
Fix: Fetch qr_code_image_url in lazy-load-properties.js

### DIFF
--- a/js/lazy-load-properties.js
+++ b/js/lazy-load-properties.js
@@ -97,7 +97,7 @@ document.addEventListener('DOMContentLoaded', () => {
             // RLS is expected to filter by user
             const { data, error } = await window._supabase
                 .from('properties')
-                .select('id, property_name, address, property_image_url, property_type')
+                .select('id, property_name, address, property_image_url, property_type, qr_code_image_url') // Added qr_code_image_url
                 .order('created_at', { ascending: false })
                 .range(offset, offset + limit - 1);
 


### PR DESCRIPTION
I've modified `js/lazy-load-properties.js` to include `qr_code_image_url` in the Supabase select query within the `fetchProperties` function.

This ensures that the QR code URL is available when rendering property cards, enabling the display of the QR icon for properties that have an associated QR code. This corrects an oversight from the previous commit for displaying QR codes.