### PR TITLE
Fix: Correct placement of 'Show QR Code' button on property details page

### DIFF
--- a/js/property-details.js
+++ b/js/property-details.js
@@ -215,7 +215,9 @@ document.addEventListener('DOMContentLoaded', async () => {
                 }
 
                 // Dynamically add "Show QR Code" button to dropdown if URL exists
-                const dropdownMenu = document.querySelector('.dropdown-menu.dropdown-menu-end'); 
+                const propertyActionsContainer = document.querySelector('.d-flex.justify-content-between.align-items-center.mb-3');
+                const dropdownMenu = propertyActionsContainer ? propertyActionsContainer.querySelector('.dropdown-menu.dropdown-menu-end') : null;
+                
                 if (dropdownMenu && loadedPropertyDataForEditing.qr_code_image_url) {
                     const existingQrButton = document.getElementById('showQrCodeDropdownButton');
                     if (existingQrButton) existingQrButton.parentElement.remove(); 


### PR DESCRIPTION
Modified `js/property-details.js` to use a more specific DOM selector for the property actions dropdown menu. Changed from a general `document.querySelector('.dropdown-menu.dropdown-menu-end')` to one scoped within the property actions header: `document.querySelector('.d-flex.justify-content-between.align-items-center.mb-3 .dropdown-menu.dropdown-menu-end')` (effectively).

This ensures the 'Show QR Code' button is added to the ellipsis dropdown menu for property-specific actions, rather than mistakenly appearing in the top-bar user dropdown menu.