### PR TITLE
Fix: Ensure QR code checkbox is visible in edit mode for properties w…

### DIFF
--- a/js/addProperty.js
+++ b/js/addProperty.js
@@ -125,14 +125,14 @@ document.addEventListener('DOMContentLoaded', () => {
     if (generateQrCheckbox) {
         const qrCheckboxContainer = generateQrCheckbox.closest('.form-check');
         if (qrCheckboxContainer) {
-            if (propertyData.qr_code_image_url) {
+            if (propertyData.qr_code_image_url && propertyData.qr_code_image_url.trim() !== '') {
                 // QR code exists: hide the checkbox container, uncheck the box, and disable
                 qrCheckboxContainer.style.display = 'none';
                 generateQrCheckbox.checked = false;
                 generateQrCheckbox.disabled = true;
             } else {
                 // No QR code: show checkbox container, ensure it's unchecked by default for edit, and enabled
-                qrCheckboxContainer.style.display = ''; // Or 'block' if it's a block element
+                qrCheckboxContainer.style.display = 'block'; // Explicitly set to block
                 generateQrCheckbox.checked = false; // User must opt-in to generate for existing property
                 generateQrCheckbox.disabled = false;
             }
@@ -479,7 +479,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (generateQrCheckbox) {
           const qrCheckboxContainer = generateQrCheckbox.closest('.form-check');
           if (qrCheckboxContainer) {
-              qrCheckboxContainer.style.display = ''; // Or 'block'
+              qrCheckboxContainer.style.display = 'block'; // Explicitly set to block for consistency
           }
           generateQrCheckbox.disabled = false; // Re-enable for add mode
           // addPropertyForm.reset() should handle setting it to the HTML default (checked)


### PR DESCRIPTION
…ithout QR codes

You reported that the "Generate QR Code" checkbox was not appearing in the Edit Property modal for properties that did not already have a QR code. This was due to the condition checking for the presence of `qr_code_image_url` not robustly handling all cases of absence (like empty strings).

This commit refines the logic in the `openEditModal` function within `js/addProperty.js`:
- The condition to determine if a QR code exists is now `if (propertyData.qr_code_image_url && propertyData.qr_code_image_url.trim() !== '')`. This ensures that `null`, `undefined`, empty strings, or strings with only whitespace in `qr_code_image_url` are all correctly interpreted as the QR code being absent.
- When a QR code is absent, the checkbox container's display style is explicitly set to `block` to ensure it becomes visible, allowing you to opt-in to generate a QR code.
- The modal reset logic was also updated to use `display = 'block'` for consistency.

This change ensures the checkbox behaves as intended, appearing when a QR code can be generated for a property being edited.