### PR TITLE
Fix: Use getElementById for QR checkbox selection in edit modal

### DIFF
--- a/js/addProperty.js
+++ b/js/addProperty.js
@@ -130,7 +130,7 @@ document.addEventListener('DOMContentLoaded', () => {
         console.log('propertyData object is null or undefined.');
     }
 
-    const generateQrCheckbox = addPropertyForm.querySelector('#generateQrCodeCheckbox');
+    const generateQrCheckbox = document.getElementById('generateQrCodeCheckbox');
     const qrCheckboxContainer = generateQrCheckbox ? generateQrCheckbox.closest('.form-check') : null;
     console.log('generateQrCheckbox element:', generateQrCheckbox);
     console.log('qrCheckboxContainer element:', qrCheckboxContainer);


### PR DESCRIPTION
Based on console logs indicating that `addPropertyForm.querySelector` was failing to find the '#generateQrCodeCheckbox', this commit changes the selection method to `document.getElementById('generateQrCodeCheckbox')` within the `openEditModal` function in `js/addProperty.js`.

Since element IDs are unique within a document, `getElementById` is a more direct and robust way to select the element if it exists in the DOM. Diagnostic logging remains in place to verify if this change successfully allows the script to find and manipulate the checkbox.