### PR TITLE
Debug: Log modal body HTML for QR checkbox issue

### DIFF
--- a/js/addProperty.js
+++ b/js/addProperty.js
@@ -510,6 +510,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
         console.log('Retrieved currentQrUrl from dataset (in shown.bs.modal):', currentQrUrl);
 
+        if (event.target.querySelector('.modal-body')) {
+            console.log('Modal body HTML (at shown.bs.modal for edit mode):', event.target.querySelector('.modal-body').innerHTML);
+        } else {
+            console.log('Modal body element (.modal-body) not found within event.target (the modal element).');
+        }
+
         const generateQrCheckbox = document.getElementById('generateQrCodeCheckbox');
         const qrCheckboxContainer = generateQrCheckbox ? generateQrCheckbox.closest('.form-check') : null;
 


### PR DESCRIPTION
To further diagnose why the 'generateQrCodeCheckbox' element is not found even within the 'shown.bs.modal' event, I've added a console.log statement that outputs the innerHTML of the modal body at that point.

This will help me verify if the checkbox element is indeed present in the DOM as expected when the modal is fully shown. The logging is added to the `shown.bs.modal` event handler in `js/addProperty.js`.