### PR TITLE
Feature: Simplify QR code generation flow

### DIFF
--- a/pages/properties.html
+++ b/pages/properties.html
@@ -119,11 +119,6 @@
               <img id="propertyImagePreview" src="#" alt="Image Preview" class="img-thumbnail mt-2" style="display:none; max-height: 200px;">
             </div>
 
-            <div class="mb-3 form-check">
-              <input type="checkbox" class="form-check-input" id="generateQrCodeCheckbox" checked>
-              <label class="form-check-label" for="generateQrCodeCheckbox" data-i18n="propertiesPage.modal.generateQrLabel">Generate and Store QR Code</label>
-            </div>
-
             <div class="modal-footer">
               <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" data-i18n="propertiesPage.modal.closeButton">Close</button>
               <button type="submit" class="btn btn-primary" data-i18n="propertiesPage.modal.saveButton">Save Property</button>


### PR DESCRIPTION
This commit implements a simplified QR code generation strategy to address persistent issues with conditional checkbox visibility and to streamline your experience.

The changes are as follows:

1.  **Always Generate QR for New Properties:**
    - The QR code generation checkbox has been removed from the "Add New Property" modal in `pages/properties.html`.
    - The JavaScript logic in `js/addProperty.js` for "add" mode now unconditionally calls `attemptQrCodeGeneration` for every new property created.

2.  **Conditional "Generate QR Code" Button in Edit Mode:**
    - In `js/addProperty.js`, when editing a property: - If the property does not already have a QR code (i.e., `qr_code_image_url` is null or empty), a "Generate QR Code" button is dynamically added to the modal when it's fully shown (using the `shown.bs.modal` event). - Clicking this button triggers the `attemptQrCodeGeneration` function for the current property. - If the property already has a QR code, this button is not displayed.
    - The placeholder for this button is cleared when the modal is hidden.

This approach ensures that QR codes are consistently generated for new properties and provides a clear mechanism for generating them for existing properties that might be missing one, while avoiding the complexities of the previous checkbox logic.