### PR TITLE
Fix: Prevent flash of placeholder data on Account page

### DIFF
--- a/js/account-details.js
+++ b/js/account-details.js
@@ -17,6 +17,17 @@ document.addEventListener('DOMContentLoaded', async () => {
     const editProfileButton = document.getElementById('editProfileButton');
     const editProfileMessageElement = document.getElementById('editProfileMessage');
 
+    // Loading state elements
+    const profileDataContainer = document.getElementById('profileDataContainer');
+    const profileLoadingIndicator = document.getElementById('profileLoadingIndicator');
+
+    if (profileDataContainer && profileLoadingIndicator) {
+        profileDataContainer.style.display = 'none';
+        profileLoadingIndicator.style.display = 'block';
+    } else {
+        console.error('Profile data container or loading indicator not found.');
+    }
+
     if (!fullNameElement || !emailAddressElement || !phoneNumberElement || !languageDisplayElement ||
         !editProfileModalElement || !editProfileForm || !modalFirstNameElement || !modalLastNameElement ||
         !modalEmailAddressElement || !modalPhoneNumberElement || !modalLanguageSelectorElement ||
@@ -111,6 +122,11 @@ document.addEventListener('DOMContentLoaded', async () => {
             emailAddressElement.value = 'Failed to load profile';
             phoneNumberElement.value = 'Failed to load profile';
             languageDisplayElement.value = 'Failed to load profile';
+        } finally {
+            if (profileDataContainer && profileLoadingIndicator) {
+                profileLoadingIndicator.style.display = 'none';
+                profileDataContainer.style.display = 'block';
+            }
         }
     };
 

--- a/pages/account.html
+++ b/pages/account.html
@@ -62,7 +62,11 @@
               <img src="https://via.placeholder.com/120" class="img-fluid rounded-circle" alt="User Avatar"> 
               -->
             </div>
-            <div class="col-md-9">
+            <div class="col-md-9" id="profileDataContainer">
+              <div id="profileLoadingIndicator" style="display: none; text-align: center; padding: 20px;">
+                <span data-i18n="loadingText.profile">Loading profile information...</span>
+                <!-- Optional: add a spinner class here if you have CSS for it -->
+              </div>
               <form>
                 <div class="mb-3">
                   <label for="fullName" class="form-label" data-i18n="accountPage.profile.fullNameLabel">Full Name</label>


### PR DESCRIPTION
Implements a loading state for the Profile Information section on `pages/account.html` to prevent the initial display of dummy data.

Changes:
- Added a "Loading profile information..." indicator to `pages/account.html`, initially hidden.
- The main container for profile data (`profileDataContainer`) is now initially hidden by `js/account-details.js` when the script loads.
- The loading indicator is displayed while `loadAndDisplayAccountDetails` fetches data.
- A `finally` block within `loadAndDisplayAccountDetails` ensures that the loading indicator is hidden and the profile data container (now populated with real data or error messages) is shown after the data fetching attempt completes.

This provides a smoother loading experience for you.