### PR TITLE
Fix: Improve account page loading indicator visibility using CSS classes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -460,3 +460,13 @@ The original request was "stroke of all borders", not necessarily hover/active s
   padding-left: 2.25rem; /* Original 0.75rem * 3 */
   padding-right: 2.25rem; /* Original 0.75rem * 3 */
 }
+
+/* Account Page Profile Loading Indicator */
+#profileLoadingIndicator {
+    display: none; /* Hidden by default via CSS */
+    /* text-align and padding will be inherited from inline style or can be moved here */
+}
+
+#profileLoadingIndicator.visible {
+    display: block !important; /* Or 'flex', etc. !important to ensure override. */
+}

--- a/js/account-details.js
+++ b/js/account-details.js
@@ -23,7 +23,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     if (profileDataContainer && profileLoadingIndicator) {
         profileDataContainer.style.display = 'none';
-        profileLoadingIndicator.style.display = 'block';
+        profileLoadingIndicator.classList.add('visible');
     } else {
         console.error('Profile data container or loading indicator not found.');
     }
@@ -124,7 +124,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             languageDisplayElement.value = 'Failed to load profile';
         } finally {
             if (profileDataContainer && profileLoadingIndicator) {
-                profileLoadingIndicator.style.display = 'none';
+                profileLoadingIndicator.classList.remove('visible');
                 profileDataContainer.style.display = 'block';
             }
         }

--- a/pages/account.html
+++ b/pages/account.html
@@ -63,7 +63,7 @@
               -->
             </div>
             <div class="col-md-9" id="profileDataContainer">
-              <div id="profileLoadingIndicator" style="display: none; text-align: center; padding: 20px;">
+              <div id="profileLoadingIndicator" style="text-align: center; padding: 20px;">
                 <span data-i18n="loadingText.profile">Loading profile information...</span>
                 <!-- Optional: add a spinner class here if you have CSS for it -->
               </div>


### PR DESCRIPTION
This commit addresses the issue where the loading indicator on the `account.html` page was not visible. The fix implements a more robust CSS class-based approach for managing the indicator's visibility.

Changes:
- In `pages/account.html`: Removed the inline `style="display: none;"` from the `profileLoadingIndicator` div.
- In `css/style.css`: Added new rules. `#profileLoadingIndicator` is now hidden by default (`display: none;`). A new class `.visible` is defined for `#profileLoadingIndicator.visible` which sets `display: block !important;` to show the indicator.
- In `js/account-details.js`:
    - Modified to use `classList.add('visible')` on the `profileLoadingIndicator` element to show it initially.
    - Modified to use `classList.remove('visible')` to hide it after data fetching is complete.

This approach should ensure the loading indicator is displayed correctly while profile data is being fetched.