### PR TITLE
Here's the rewritten message:

### DIFF
--- a/js/account-details.js
+++ b/js/account-details.js
@@ -24,6 +24,23 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (profileDataContainer && profileLoadingIndicator) {
         profileDataContainer.style.display = 'none';
         profileLoadingIndicator.classList.add('visible');
+        // ---- START DEBUG STYLING ----
+        profileLoadingIndicator.style.backgroundColor = 'lime';
+        profileLoadingIndicator.style.color = 'black';
+        // Padding is already applied via inline style in HTML or CSS, but we can ensure it here too.
+        // profileLoadingIndicator.style.padding = '20px';
+        profileLoadingIndicator.style.border = '5px solid red';
+        profileLoadingIndicator.style.fontSize = '20px';
+        profileLoadingIndicator.style.position = 'fixed'; // Use fixed to ensure it's in viewport
+        profileLoadingIndicator.style.top = '40%'; // Position it clearly
+        profileLoadingIndicator.style.left = '30%';
+        profileLoadingIndicator.style.width = '40%'; // Give it some dimensions
+        profileLoadingIndicator.style.height = 'auto'; // Auto height based on content
+        profileLoadingIndicator.style.minHeight = '50px'; // Ensure it has some min height
+        profileLoadingIndicator.style.zIndex = '99999'; // Max z-index
+        profileLoadingIndicator.textContent = 'DEBUG: PROFILE LOADER IS HERE AND SHOULD BE VISIBLE!'; // Override text content for debug
+        console.log('DEBUG: Applied debug styles to profileLoadingIndicator.');
+        // ---- END DEBUG STYLING ----
     } else {
         console.error('Profile data container or loading indicator not found.');
     }
@@ -124,8 +141,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             languageDisplayElement.value = 'Failed to load profile';
         } finally {
             if (profileDataContainer && profileLoadingIndicator) {
-                profileLoadingIndicator.classList.remove('visible');
-                profileDataContainer.style.display = 'block';
+                // profileLoadingIndicator.classList.remove('visible');
+                // profileDataContainer.style.display = 'block';
             }
         }
     };


### PR DESCRIPTION
Debug: Force visibility of account page loader

To diagnose why the loading indicator on `pages/account.html` is not appearing, I've introduced temporary debugging measures in `js/account-details.js`:

- Aggressive inline CSS styles (bright background, border, fixed position, high z-index, modified text content) are applied to the `profileLoadingIndicator` element when it is made visible.
- The code that normally hides the loading indicator and shows the profile data container in the `finally` block of `loadAndDisplayAccountDetails` has been temporarily commented out.

This should make the loading indicator persistently and prominently visible if the JavaScript is correctly finding the element and attempting to display it.