### PR TITLE
Debug: Relocate account page loader HTML for visibility test

### DIFF
--- a/pages/account.html
+++ b/pages/account.html
@@ -54,6 +54,10 @@
           <h5 class="mb-0" data-i18n="accountPage.profile.title">Profile Information</h5>
         </div>
         <div class="card-body">
+          <div id="profileLoadingIndicator" style="text-align: center; padding: 20px;">
+            <span data-i18n="loadingText.profile">Loading profile information...</span>
+            <!-- Optional: add a spinner class here if you have CSS for it -->
+          </div>
           <div class="row align-items-center">
             <div class="col-md-3 text-center mb-3 mb-md-0">
               <!-- Placeholder for Avatar -->
@@ -63,10 +67,6 @@
               -->
             </div>
             <div class="col-md-9" id="profileDataContainer">
-              <div id="profileLoadingIndicator" style="text-align: center; padding: 20px;">
-                <span data-i18n="loadingText.profile">Loading profile information...</span>
-                <!-- Optional: add a spinner class here if you have CSS for it -->
-              </div>
               <form>
                 <div class="mb-3">
                   <label for="fullName" class="form-label" data-i18n="accountPage.profile.fullNameLabel">Full Name</label>


### PR DESCRIPTION
This commit modifies `pages/account.html` to move the `profileLoadingIndicator` div. Previously, it was a child of `profileDataContainer`. Since `profileDataContainer` was being explicitly hidden (`display: none;`) during the loading phase for debugging purposes, this also hid the loader.

The `profileLoadingIndicator` is now a direct child of the `.card-body` in the "Profile Information" section, and positioned before the row that contains `profileDataContainer`. This makes its visibility independent of `profileDataContainer`.

The JavaScript (`js/account-details.js`) remains in its debug state (aggressive styling for the loader, loader not hidden, data container not shown) to test if the loader now appears with this structural change.