### PR TITLE
feat: Implement agency account signup and company setup flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,24 +64,48 @@
 
           <!-- Sign Up Section View -->
           <div id="signUpFormSectionView" style="display: none;">
-            <h2 class="h3 mb-1 fw-semibold" data-i18n="signUpPage.formTitle">Create Account</h2>
-            <p class="text-muted mb-4" data-i18n="signUpPage.formSubtitle">Fill out the form below to get started.</p>
-            <form id="signUpForm">
+            <!-- Account Type Selection Step -->
+            <div id="accountTypeSelectionView">
+              <h2 class="h3 mb-1 fw-semibold" data-i18n="signUpPage.accountTypeTitle">Select Account Type</h2>
+              <p class="text-muted mb-4" data-i18n="signUpPage.accountTypeSubtitle">Choose how you want to use Property Hub.</p>
               <div class="form-floating mb-3">
-                <input type="text" class="form-control" id="signUpFirstName" placeholder="John Doe" required>
-                <label for="signUpFirstName" data-i18n="signUpPage.firstNameLabel">First Name</label>
+                <select class="form-select" id="accountTypeSelect">
+                  <option value="agency" selected data-i18n="signUpPage.accountType.agency">Agency Account</option>
+                  <option value="user" data-i18n="signUpPage.accountType.user">User Account</option>
+                </select>
+                <label for="accountTypeSelect" data-i18n="signUpPage.accountTypeLabel">Account Type</label>
               </div>
-              <div class="form-floating mb-3">
-                <input type="email" class="form-control" id="signUpEmail" placeholder="name@example.com" required>
-                <label for="signUpEmail" data-i18n="signUpPage.emailLabel">Email address</label>
-              </div>
-              <div class="form-floating mb-3">
-                <input type="password" class="form-control" id="signUpPassword" placeholder="Password" required minlength="6">
-                <label for="signUpPassword" data-i18n="signUpPage.passwordLabel">Password</label>
-              </div>
-              <button class="btn btn-primary w-100 py-2" type="submit" id="signUpButton" data-i18n="signUpPage.signUpButton">Sign Up</button>
-              <div id="signUpUserMessage" class="mt-3"></div>
-            </form>
+              <button class="btn btn-primary w-100 py-2" id="accountTypeContinueButton" data-i18n="signUpPage.continueButton">Continue</button>
+            </div>
+
+            <!-- User Account Info View (Initially Hidden) -->
+            <div id="userAccountInfoView" style="display: none;">
+              <h2 class="h3 mb-1 fw-semibold" data-i18n="signUpPage.userAccountInfoTitle">User Account Information</h2>
+              <p class="text-muted mb-4" data-i18n="signUpPage.userAccountInfoText">How to set up a new account: As a User, you require to have an account set up by the Agency that is managing your property. Please get in touch with them and ask them to set you up with a new account. Once done, you can sign into your account on the Sign In page.</p>
+              <!-- Optional: Add a button to go back to account type selection or to Sign In page -->
+            </div>
+
+            <!-- Agency Signup Form View (Initially Hidden) -->
+            <div id="agencySignupFormView" style="display: none;">
+              <h2 class="h3 mb-1 fw-semibold" data-i18n="signUpPage.formTitle">Create Agency Account</h2>
+              <p class="text-muted mb-4" data-i18n="signUpPage.formSubtitle">Fill out the form below to get started.</p>
+              <form id="signUpForm">
+                <div class="form-floating mb-3">
+                  <input type="text" class="form-control" id="signUpFirstName" placeholder="John Doe" required>
+                  <label for="signUpFirstName" data-i18n="signUpPage.firstNameLabel">First Name</label>
+                </div>
+                <div class="form-floating mb-3">
+                  <input type="email" class="form-control" id="signUpEmail" placeholder="name@example.com" required>
+                  <label for="signUpEmail" data-i18n="signUpPage.emailLabel">Email address</label>
+                </div>
+                <div class="form-floating mb-3">
+                  <input type="password" class="form-control" id="signUpPassword" placeholder="Password" required minlength="6">
+                  <label for="signUpPassword" data-i18n="signUpPage.passwordLabel">Password</label>
+                </div>
+                <button class="btn btn-primary w-100 py-2" type="submit" id="signUpButton" data-i18n="signUpPage.signUpButton">Sign Up</button>
+                <div id="signUpUserMessage" class="mt-3"></div>
+              </form>
+            </div>
           </div>
           <p class="mt-5 mb-3 text-muted text-center">&copy; <span id="currentYear"></span> Property Hub</p>
         </div>

--- a/js/agency_setup.js
+++ b/js/agency_setup.js
@@ -1,0 +1,196 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const agencySetupForm = document.getElementById('agencySetupForm');
+    const companyLogoInput = document.getElementById('companyLogo');
+    const logoPreview = document.getElementById('logoPreview');
+
+    const companyNameInput = document.getElementById('companyName');
+    const companyAddressStreetInput = document.getElementById('companyAddressStreet');
+    const companyEmailInput = document.getElementById('companyEmail');
+    const companyCityInput = document.getElementById('companyCity');
+    const companyStateInput = document.getElementById('companyState');
+    const companyPostCodeInput = document.getElementById('companyPostCode');
+
+    const companyPhoneInput = document.getElementById('companyPhone');
+    const companyWebsiteInput = document.getElementById('companyWebsite');
+    const companyTaxIdInput = document.getElementById('companyTaxId');
+
+    const saveCompanyButton = document.getElementById('saveCompanyButton');
+    const agencySetupMessage = document.getElementById('agencySetupMessage');
+
+    // Basic i18n placeholder for messages
+    const i18n = {
+        t: (key, options) => {
+            let message = key;
+            if (options && options.message) {
+                message = message.replace('{{message}}', options.message);
+            }
+            if (options && options.email) {
+                message = message.replace('{{email}}', options.email);
+            }
+            // Add more replacements if needed
+            switch (key) {
+                case 'agencySetup.validation.requiredFields': return 'Please fill in all required fields.';
+                case 'agencySetup.validation.invalidEmail': return 'Please enter a valid email address.';
+                case 'agencySetup.error.noSession': return 'No active session. Please log in again.';
+                case 'agencySetup.error.logoUploadFailed': return 'Logo upload failed: {{message}}';
+                case 'agencySetup.error.getPublicUrlFailed': return 'Failed to get logo URL: {{message}}';
+                case 'agencySetup.error.functionInvocationFailed': return 'Failed to save company details: {{message}}';
+                case 'agencySetup.error.unexpected': return 'An unexpected error occurred: {{message}}';
+                case 'agencySetup.success': return 'Company information saved successfully! Redirecting...';
+                default: return key;
+            }
+        }
+    };
+
+    function displayMessage(message, type = 'danger') {
+        if (agencySetupMessage) {
+            agencySetupMessage.innerHTML = `<div class="alert alert-${type} alert-dismissible fade show" role="alert">
+                ${message}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>`;
+        }
+    }
+
+    // Logo Preview Logic
+    if (companyLogoInput && logoPreview) {
+        companyLogoInput.addEventListener('change', function () {
+            const file = this.files[0];
+            if (file) {
+                const reader = new FileReader();
+                reader.onload = function (e) {
+                    logoPreview.src = e.target.result;
+                    logoPreview.style.display = 'block';
+                }
+                reader.readAsDataURL(file);
+            } else {
+                logoPreview.src = '#';
+                logoPreview.style.display = 'none';
+            }
+        });
+    }
+
+    if (agencySetupForm) {
+        agencySetupForm.addEventListener('submit', async function (event) {
+            event.preventDefault();
+            if (agencySetupMessage) agencySetupMessage.innerHTML = '';
+            if (saveCompanyButton) saveCompanyButton.disabled = true;
+
+            // Client-Side Validation
+            const requiredFields = [
+                companyNameInput, companyAddressStreetInput, companyEmailInput,
+                companyCityInput, companyStateInput, companyPostCodeInput
+            ];
+            let allFieldsValid = true;
+            for (const field of requiredFields) {
+                if (!field.value.trim()) {
+                    allFieldsValid = false;
+                    field.classList.add('is-invalid');
+                } else {
+                    field.classList.remove('is-invalid');
+                }
+            }
+
+            if (!allFieldsValid) {
+                displayMessage(i18n.t('agencySetup.validation.requiredFields'), 'warning');
+                if (saveCompanyButton) saveCompanyButton.disabled = false;
+                return;
+            }
+
+            const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+            if (!emailRegex.test(companyEmailInput.value.trim())) {
+                displayMessage(i18n.t('agencySetup.validation.invalidEmail'), 'warning');
+                companyEmailInput.classList.add('is-invalid');
+                if (saveCompanyButton) saveCompanyButton.disabled = false;
+                return;
+            } else {
+                companyEmailInput.classList.remove('is-invalid');
+            }
+
+            try {
+                const { data: sessionData, error: sessionError } = await window._supabase.auth.getSession();
+                if (sessionError || !sessionData.session || !sessionData.session.user) {
+                    displayMessage(i18n.t('agencySetup.error.noSession'), 'danger');
+                    if (saveCompanyButton) saveCompanyButton.disabled = false;
+                    // Consider redirect: window.location.href = '../index.html';
+                    return;
+                }
+                const user = sessionData.session.user;
+
+                let companyLogoUrl = null;
+                const logoFile = companyLogoInput.files[0];
+
+                if (logoFile) {
+                    const fileExtension = logoFile.name.split('.').pop();
+                    const filePath = `${user.id}/logo-${Date.now()}.${fileExtension}`;
+
+                    const { error: uploadError } = await window._supabase.storage
+                        .from('agency-logo')
+                        .upload(filePath, logoFile, {
+                            cacheControl: '3600', // Optional: cache for 1 hour
+                            upsert: true // Optional: overwrite if file with same path exists
+                        });
+
+                    if (uploadError) {
+                        displayMessage(i18n.t('agencySetup.error.logoUploadFailed', { message: uploadError.message }), 'danger');
+                        if (saveCompanyButton) saveCompanyButton.disabled = false;
+                        return;
+                    }
+
+                    const { data: publicUrlData, error: publicUrlError } = window._supabase.storage
+                        .from('agency-logo')
+                        .getPublicUrl(filePath);
+
+                    if (publicUrlError) {
+                        displayMessage(i18n.t('agencySetup.error.getPublicUrlFailed', { message: publicUrlError.message }), 'danger');
+                        // Log this, but proceed without logo if getting URL fails after successful upload
+                        console.error("Error getting public URL for logo:", publicUrlError);
+                    } else if (publicUrlData) {
+                        companyLogoUrl = publicUrlData.publicUrl;
+                    }
+                }
+
+                const companyData = {
+                    company_name: companyNameInput.value.trim(),
+                    company_address_street: companyAddressStreetInput.value.trim(),
+                    company_email: companyEmailInput.value.trim(),
+                    company_city: companyCityInput.value.trim(),
+                    company_state: companyStateInput.value.trim(),
+                    company_address_zip: companyPostCodeInput.value.trim(), // Renamed from companyPostCodeInput for consistency
+                    company_phone: companyPhoneInput.value.trim() || null,
+                    company_website: companyWebsiteInput.value.trim() || null,
+                    company_tax_id: companyTaxIdInput.value.trim() || null,
+                    company_logo_url: companyLogoUrl
+                };
+
+                // Invoke Supabase Edge Function
+                const { data: functionResponse, error: functionError } = await window._supabase.functions.invoke('save-company-details', {
+                    body: companyData
+                });
+
+                if (functionError) {
+                    displayMessage(i18n.t('agencySetup.error.functionInvocationFailed', { message: functionError.message }), 'danger');
+                    if (saveCompanyButton) saveCompanyButton.disabled = false;
+                    return;
+                }
+
+                // Assuming the function returns a structure like { success: true } or { success: false, message: '...' }
+                // Adjust based on actual function response
+                if (functionResponse && (functionResponse.success || functionResponse.data?.success)) { // Check for success in response or response.data
+                    displayMessage(i18n.t('agencySetup.success'), 'success');
+                    setTimeout(() => {
+                        window.location.href = '../pages/dashboard.html';
+                    }, 2000);
+                } else {
+                    const errorMessage = functionResponse?.message || functionResponse?.data?.message || 'Unknown error from function.';
+                    displayMessage(i18n.t('agencySetup.error.functionInvocationFailed', { message: errorMessage }), 'danger');
+                    if (saveCompanyButton) saveCompanyButton.disabled = false;
+                }
+
+            } catch (error) {
+                console.error("Unexpected error during company setup:", error);
+                displayMessage(i18n.t('agencySetup.error.unexpected', { message: error.message }), 'danger');
+                if (saveCompanyButton) saveCompanyButton.disabled = false;
+            }
+        });
+    }
+});

--- a/pages/agency_setup_page.html
+++ b/pages/agency_setup_page.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title data-i18n-title="agencySetupPage.pageTitle">Agency Company Setup - Property Hub</title>
+  <script src="https://cdn.jsdelivr.net/npm/i18next/i18next.min.js"></script>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body class="bg-light">
+  <div class="page-content-wrapper">
+    <div class="container mt-5 mb-5">
+      <div class="row justify-content-center">
+        <div class="col-md-8 col-lg-7">
+          <div class="card shadow-sm">
+            <div class="card-body p-4 p-md-5">
+              <h1 class="h3 mb-4 fw-semibold text-center" data-i18n="agencySetupPage.mainTitle">Set Up Your Agency Company</h1>
+              <p class="text-muted mb-4 text-center" data-i18n="agencySetupPage.mainSubtitle">Please provide your company details below to complete your agency profile.</p>
+
+              <form id="agencySetupForm">
+                <!-- Company Logo -->
+                <div class="mb-3">
+                  <label for="companyLogo" class="form-label" data-i18n="agencySetupPage.logoLabel">Company Logo (Optional)</label>
+                  <input class="form-control" type="file" id="companyLogo" accept="image/*">
+                  <div class="mt-2 text-center">
+                    <img id="logoPreview" src="#" alt="Logo Preview" class="img-thumbnail" style="max-width: 150px; max-height: 150px; display: none;">
+                  </div>
+                </div>
+
+                <!-- Company Name -->
+                <div class="form-floating mb-3">
+                  <input type="text" class="form-control" id="companyName" placeholder="Your Company LLC" required>
+                  <label for="companyName" data-i18n="agencySetupPage.nameLabel">Company Name</label>
+                </div>
+
+                <!-- Company Address (Street) -->
+                <div class="form-floating mb-3">
+                  <input type="text" class="form-control" id="companyAddressStreet" placeholder="123 Main St" required>
+                  <label for="companyAddressStreet" data-i18n="agencySetupPage.addressStreetLabel">Company Address (Street and Number)</label>
+                </div>
+
+                <!-- Company City -->
+                <div class="form-floating mb-3">
+                  <input type="text" class="form-control" id="companyCity" placeholder="Anytown" required>
+                  <label for="companyCity" data-i18n="agencySetupPage.cityLabel">Company City</label>
+                </div>
+
+                <!-- Company State -->
+                <div class="form-floating mb-3">
+                  <input type="text" class="form-control" id="companyState" placeholder="CA" required>
+                  <label for="companyState" data-i18n="agencySetupPage.stateLabel">Company State</label>
+                </div>
+
+                <!-- Company Post Code -->
+                <div class="form-floating mb-3">
+                  <input type="text" class="form-control" id="companyPostCode" placeholder="90210" required>
+                  <label for="companyPostCode" data-i18n="agencySetupPage.postCodeLabel">Company Post Code</label>
+                </div>
+
+                <!-- Company Email -->
+                <div class="form-floating mb-3">
+                  <input type="email" class="form-control" id="companyEmail" placeholder="contact@yourcompany.com" required>
+                  <label for="companyEmail" data-i18n="agencySetupPage.emailLabel">Company Email</label>
+                </div>
+
+                <!-- Company Phone -->
+                <div class="form-floating mb-3">
+                  <input type="tel" class="form-control" id="companyPhone" placeholder="(555) 123-4567">
+                  <label for="companyPhone" data-i18n="agencySetupPage.phoneLabel">Company Phone (Optional)</label>
+                </div>
+
+                <!-- Company Website -->
+                <div class="form-floating mb-3">
+                  <input type="url" class="form-control" id="companyWebsite" placeholder="https://yourcompany.com">
+                  <label for="companyWebsite" data-i18n="agencySetupPage.websiteLabel">Company Website (Optional)</label>
+                </div>
+
+                <!-- Company Tax ID -->
+                <div class="form-floating mb-3">
+                  <input type="text" class="form-control" id="companyTaxId" placeholder="Your Tax ID or VAT Number">
+                  <label for="companyTaxId" data-i18n="agencySetupPage.taxIdLabel">Company Tax ID / VAT Number (Optional)</label>
+                </div>
+
+                <button type="submit" class="btn btn-primary w-100 py-2 mt-3" id="saveCompanyButton" data-i18n="agencySetupPage.saveButton">Save Company Information</button>
+
+                <div id="agencySetupMessage" class="mt-3"></div>
+              </form>
+            </div>
+          </div>
+           <p class="mt-4 mb-3 text-muted text-center">&copy; <span id="currentYear"></span> Property Hub</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="../js/supabase-config.js"></script>
+  <script type="module" src="../js/supabase-client.js"></script>
+  <script type="module" src="../js/agency_setup.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
+  <!-- Placeholder for i18n initialization, if needed on this page specifically -->
+  <!-- <script type="module" src="../js/i18n.js"></script> -->
+   <script>
+    // Dynamic Year for Footer
+    const currentYearSpan = document.getElementById('currentYear');
+    if (currentYearSpan) {
+      currentYearSpan.textContent = new Date().getFullYear();
+    }
+    // Basic i18n placeholder - will be replaced by actual i18n logic if page-specific init is used
+    // For now, this ensures data-i18n attributes don't cause errors if i18n.js isn't loaded for this page.
+    window.i18next = window.i18next || { t: (key) => key.split('.').pop() };
+    document.addEventListener('DOMContentLoaded', () => {
+        document.querySelectorAll('[data-i18n]').forEach(el => {
+            el.textContent = i18next.t(el.getAttribute('data-i18n'));
+        });
+        document.querySelectorAll('[data-i18n-title]').forEach(el => {
+            document.title = i18next.t(el.getAttribute('data-i18n-title'));
+        });
+        document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+            el.placeholder = i18next.t(el.getAttribute('data-i18n-placeholder'));
+        });
+    });
+  </script>
+</body>
+</html>

--- a/schema_modifications.sql
+++ b/schema_modifications.sql
@@ -1,0 +1,23 @@
+-- Alter profiles table
+ALTER TABLE profiles
+ADD COLUMN IF NOT EXISTS is_admin BOOLEAN DEFAULT FALSE;
+
+ALTER TABLE profiles
+ADD COLUMN IF NOT EXISTS has_company_set_up BOOLEAN DEFAULT FALSE;
+
+-- Create companies table
+CREATE TABLE IF NOT EXISTS companies (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+    company_logo_url TEXT,
+    company_name TEXT NOT NULL,
+    company_address_street TEXT NOT NULL,
+    company_phone TEXT,
+    company_email TEXT NOT NULL,
+    company_address_city TEXT NOT NULL,
+    company_address_state TEXT NOT NULL,
+    company_address_zip TEXT NOT NULL,
+    company_website TEXT,
+    company_tax_id TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL
+);

--- a/storage_setup.sql
+++ b/storage_setup.sql
@@ -1,0 +1,49 @@
+-- Create the storage bucket for agency logos
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES ('agency-logo', 'agency-logo', FALSE, 5242880, ARRAY['image/jpeg', 'image/png', 'image/gif'])
+ON CONFLICT (id) DO NOTHING;
+
+-- Enable RLS on storage.objects table (if not already enabled)
+-- Supabase usually has this enabled by default. If this command fails, it's likely already enabled.
+ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies for 'agency-logo' bucket
+
+-- 1. Policy: Authenticated users can upload logos into their own folder
+CREATE POLICY "Authenticated users can upload logos"
+ON storage.objects FOR INSERT TO authenticated
+WITH CHECK (
+    bucket_id = 'agency-logo'
+    AND auth.role() = 'authenticated' -- Redundant with "TO authenticated" but good for clarity
+    AND (storage.foldername(name))[1] = auth.uid()::text -- Files must be in a folder named after the user's ID
+);
+
+-- 2. Policy: Allow public read access to objects in 'agency-logo' bucket
+CREATE POLICY "Public can read logos"
+ON storage.objects FOR SELECT TO anon, authenticated -- Or just `public` role if that's how Supabase handles it broadly
+USING (
+    bucket_id = 'agency-logo'
+);
+
+-- 3. Policy: Owners can update their own logos
+CREATE POLICY "Owners can update their own logos"
+ON storage.objects FOR UPDATE TO authenticated
+USING (
+    bucket_id = 'agency-logo'
+    AND auth.role() = 'authenticated'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+)
+WITH CHECK (
+    bucket_id = 'agency-logo'
+    AND auth.role() = 'authenticated'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- 4. Policy: Owners can delete their own logos
+CREATE POLICY "Owners can delete their own logos"
+ON storage.objects FOR DELETE TO authenticated
+USING (
+    bucket_id = 'agency-logo'
+    AND auth.role() = 'authenticated'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+);

--- a/supabase/functions/save-company-details/index.ts
+++ b/supabase/functions/save-company-details/index.ts
@@ -1,0 +1,169 @@
+import { serve } from 'https://deno.land/std@0.161.0/http/server.ts'
+import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+// Define a type for the expected request body
+interface CompanyData {
+  company_name: string;
+  company_address_street: string;
+  company_email: string;
+  company_city: string;
+  company_state: string;
+  company_address_zip: string; // Matched to client-side js/agency_setup.js
+  company_phone?: string | null;
+  company_website?: string | null;
+  company_tax_id?: string | null;
+  company_logo_url?: string | null;
+}
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*', // Adjust for production; '*' is permissive
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS', // Specify allowed methods
+};
+
+serve(async (req: Request) => {
+  // Handle OPTIONS request for CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL');
+    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+    const anonKey = Deno.env.get('SUPABASE_ANON_KEY');
+
+    if (!supabaseUrl || !serviceRoleKey || !anonKey) {
+      console.error('Missing Supabase environment variables');
+      return new Response(JSON.stringify({ error: 'Server configuration error: Missing Supabase environment variables.' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Create Supabase admin client for privileged operations
+    const supabaseAdminClient = createClient(supabaseUrl, serviceRoleKey);
+
+    // 1. Get User from JWT
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: 'Missing authorization header.' }), {
+        status: 401, // Unauthorized
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Create a client with the user's token to verify their identity
+    const userSupabaseClient = createClient(supabaseUrl, anonKey, {
+      global: { headers: { Authorization: authHeader } },
+    });
+    const { data: { user }, error: userError } = await userSupabaseClient.auth.getUser();
+
+    if (userError || !user) {
+      console.error('User retrieval error:', userError?.message || 'User not found.');
+      return new Response(JSON.stringify({ error: 'Invalid token or user not found.' }), {
+        status: 403, // Forbidden
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+    const userId = user.id;
+
+    // 2. Parse Request Body
+    if (req.body === null) {
+        return new Response(JSON.stringify({ error: 'Request body is missing.' }), {
+        status: 400, // Bad Request
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+    const companyData = (await req.json()) as CompanyData;
+
+    // 3. Server-Side Validation
+    const requiredFields: (keyof CompanyData)[] = [
+      'company_name', 'company_address_street', 'company_email',
+      'company_city', 'company_state', 'company_address_zip'
+    ];
+    const missingFields = requiredFields.filter(field => !companyData[field]);
+
+    if (missingFields.length > 0) {
+      return new Response(JSON.stringify({ error: `Missing required company fields: ${missingFields.join(', ')}.` }), {
+        status: 400, // Bad Request
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Basic email validation
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(companyData.company_email)) {
+      return new Response(JSON.stringify({ error: 'Invalid company email format.' }), {
+        status: 400, // Bad Request
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // 4. Database Operations (using admin client)
+    // Insert into companies table
+    const { data: companyInsertData, error: companyInsertError } = await supabaseAdminClient
+      .from('companies')
+      .insert([{
+        owner_id: userId,
+        company_name: companyData.company_name,
+        company_address_street: companyData.company_address_street,
+        company_email: companyData.company_email,
+        company_city: companyData.company_city,
+        company_state: companyData.company_state,
+        company_address_zip: companyData.company_address_zip,
+        company_phone: companyData.company_phone || null,
+        company_website: companyData.company_website || null,
+        company_tax_id: companyData.company_tax_id || null,
+        company_logo_url: companyData.company_logo_url || null,
+      }])
+      .select()
+      .single();
+
+    if (companyInsertError) {
+      console.error('Error inserting company:', companyInsertError.message);
+      return new Response(JSON.stringify({ error: 'Failed to save company information.', details: companyInsertError.message }), {
+        status: 500, // Internal Server Error
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Update profiles table
+    const { error: profileUpdateError } = await supabaseAdminClient
+      .from('profiles')
+      .update({ is_admin: true, has_company_set_up: true })
+      .eq('id', userId);
+
+    if (profileUpdateError) {
+      console.error('Error updating profile:', profileUpdateError.message);
+      // CRITICAL: Company was inserted, but profile update failed.
+      // This state should be logged for potential manual reconciliation.
+      // For now, return an error indicating partial success or specific failure.
+      return new Response(JSON.stringify({
+        error: 'Company information saved, but failed to update profile status. Please contact support.',
+        details: profileUpdateError.message
+      }), {
+        status: 500, // Internal Server Error (or a custom status code)
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify({ success: true, message: 'Company details saved successfully.', company: companyInsertData }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 200, // OK or 201 Created
+    });
+
+  } catch (e) {
+    console.error('Unexpected error in function:', e.message, e.stack);
+    // Check if it's a JSON parsing error
+    if (e instanceof SyntaxError && e.message.includes('JSON')) {
+        return new Response(JSON.stringify({ error: 'Invalid JSON in request body.', details: e.message }), {
+            status: 400, // Bad Request
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+    }
+    return new Response(JSON.stringify({ error: 'Server error.', details: e.message }), {
+      status: 500, // Internal Server Error
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+})


### PR DESCRIPTION
Introduces a multi-step signup process allowing you to select an account type (User or Agency).

Key changes include:

- Modified the signup page (index.html, js/main.js) to:
  - Initially display an account type dropdown (User/Agency).
  - Show informational text for "User Account" selections.
  - Present the standard signup form for "Agency Account" selections.
- Created a new Agency Setup page (pages/agency_setup_page.html and js/agency_setup.js) for agency users to input their company details after their first login and email/code verification. This form includes fields for company name, address, contact info, and an optional logo upload.
- Implemented logo uploads to a new Supabase Storage bucket 'agency-logo' with RLS policies for secure access.
- Added a Supabase Edge Function 'save-company-details' to:
  - Validate and save company information to a new 'companies' table.
  - Update the user's 'profiles' table (is_admin=TRUE, has_company_set_up=TRUE).
- Updated redirection logic in js/main.js to route new agency users to the agency setup page after initial verification, and then to the dashboard upon completion.
- Database schema changes:
  - Added 'is_admin' and 'has_company_set_up' columns to 'profiles'.
  - Created the 'companies' table to store agency company details.

This feature enhances the onboarding process by catering to different user roles from the point of signup.