### PR TITLE
fix(edge-function): Correct db column name for city

### DIFF
--- a/supabase/functions/save-company-details/index.ts
+++ b/supabase/functions/save-company-details/index.ts
@@ -108,7 +108,7 @@ serve(async (req: Request) => {
         company_name: companyData.company_name,
         company_address_street: companyData.company_address_street,
         company_email: companyData.company_email,
-        company_city: companyData.company_city,
+        company_address_city: companyData.company_city,
         company_state: companyData.company_state,
         company_address_zip: companyData.company_address_zip,
         company_phone: companyData.company_phone || null,


### PR DESCRIPTION
In the 'save-company-details' Edge Function, I changed the insert key from 'company_city' to 'company_address_city' to match the actual column name in the 'companies' table. This resolves a 500 error during company data insertion.