### PR TITLE
fix(edge-function): Correct db column name for state

### DIFF
--- a/supabase/functions/save-company-details/index.ts
+++ b/supabase/functions/save-company-details/index.ts
@@ -109,7 +109,7 @@ serve(async (req: Request) => {
         company_address_street: companyData.company_address_street,
         company_email: companyData.company_email,
         company_address_city: companyData.company_city,
-        company_state: companyData.company_state,
+        company_address_state: companyData.company_state,
         company_address_zip: companyData.company_address_zip,
         company_phone: companyData.company_phone || null,
         company_website: companyData.company_website || null,


### PR DESCRIPTION
In the 'save-company-details' Edge Function, changed the insert key from 'company_state' to 'company_address_state' to match the actual column name in the 'companies' table. This resolves a 500 error related to the state field during company data insertion.