### PR TITLE
refactor: Rename 'Add New Task' to 'Create Task' for button and modal

### DIFF
--- a/pages/tasks.html
+++ b/pages/tasks.html
@@ -78,7 +78,7 @@
           </select>
         </div>
         <div class="col-md-2 text-end d-none" id="addNewTaskBtnContainer">
-          <button class="btn btn-primary" id="addNewTaskBtn" type="button">Add New Task</button>
+          <button class="btn btn-primary" id="addNewTaskBtn" type="button">Create Task</button>
         </div>
       </div>
 
@@ -147,7 +147,7 @@
     <div class="modal-dialog modal-lg">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title" id="addNewTaskModalLabel">Add New Task</h5>
+          <h5 class="modal-title" id="addNewTaskModalLabel">Create Task</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">


### PR DESCRIPTION
Updated the text on the tasks page:
- The button for initiating task creation (formerly 'Add New Task') is now labeled 'Create Task'.
- The modal title for task creation (formerly 'Add New Task') is now 'Create Task'.

This change is based on your feedback for clearer terminology.