### PR TITLE
feat: Style 'New' task status with blue badge and remove debug logs

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -296,6 +296,11 @@ body {
   background-color: #DCFCE7 !important;
 }
 
+.badge-custom-blue {
+  color: #0D6EFD !important; /* Bootstrap primary blue for text */
+  background-color: #E7F0FF !important; /* A very light blue for background */
+}
+
 /* Global Border Color Overrides to #E5E7EB */
 
 /* Form Inputs */

--- a/js/tasks-display.js
+++ b/js/tasks-display.js
@@ -159,12 +159,11 @@ function renderTasks(tasks) {
     let statusText = task.status || 'N/A'; // Default text
 
     // Normalize status for comparison and determine display text
-    console.log('Processing status raw:', task.status, '| Lowercase for switch:', (task.status || '').toLowerCase());
     const lowerCaseStatus = (task.status || '').toLowerCase();
 
     switch (lowerCaseStatus) {
       case 'new':
-        statusSpan.classList.add('badge-custom-yellow');
+        statusSpan.classList.add('badge-custom-blue');
         statusText = 'New';
         break;
       case 'not started':


### PR DESCRIPTION
Updates the styling for task statuses on the tasks page:
- Added a new CSS class `.badge-custom-blue` to `css/style.css` for a blue-toned badge.
- Modified `js/tasks-display.js` in the `renderTasks` function:
    - "New" task statuses are now styled using the new `badge-custom-blue` class instead of yellow.
    - Removed a diagnostic `console.log` statement that was previously added for debugging status string values.

This change provides a distinct visual style for 'New' tasks and cleans up unnecessary logging.