### PR TITLE
fix: Add top margin to tasks table

### DIFF
--- a/pages/tasks.html
+++ b/pages/tasks.html
@@ -82,7 +82,7 @@
         </div>
       </div>
 
-      <table class="table table-hover align-middle">
+      <table class="table table-hover align-middle mt-3">
         <thead class="table-light">
           <tr>
             <th scope="col">Task title</th>


### PR DESCRIPTION
Added `mt-3` Bootstrap class to the `<table>` element on `pages/tasks.html` to create more vertical space between the search/filter bar and the table itself.