### PR TITLE
fix: Update tasks table top margin to mt-5

### DIFF
--- a/pages/tasks.html
+++ b/pages/tasks.html
@@ -82,7 +82,7 @@
         </div>
       </div>
 
-      <table class="table table-hover align-middle mt-3">
+      <table class="table table-hover align-middle mt-5">
         <thead class="table-light">
           <tr>
             <th scope="col">Task title</th>


### PR DESCRIPTION
I changed the Bootstrap margin utility class for the tasks table on `pages/tasks.html` from `mt-3` to `mt-5` to increase the vertical space between the search/filter bar and the table, as per your request.