### PR TITLE
feat: Implement role-based navigation and access control

### DIFF
--- a/js/admin-page-guard.js
+++ b/js/admin-page-guard.js
@@ -1,0 +1,89 @@
+// js/admin-page-guard.js
+(async function checkAdminAccessAndRedirect() {
+  // Try to hide main content quickly to prevent flash of content on admin pages.
+  // This assumes your main page content (excluding sidebar/topbar if they are separate)
+  // is wrapped in a div with id 'pageSpecificContent' or similar.
+  // If not, this part might need adjustment or be handled by initially hiding content via CSS.
+  const pageSpecificContent = document.getElementById('pageSpecificContent'); // Placeholder ID
+  if (pageSpecificContent) {
+    pageSpecificContent.style.display = 'none';
+  } else {
+    console.warn('Admin Page Guard: Could not find #pageSpecificContent to hide initially. Consider wrapping page content.');
+  }
+
+  if (!window._supabase) {
+    console.error('Supabase client not available for admin page guard. Redirecting to login.');
+    window.location.href = '../index.html'; // Adjust if your login page is different
+    return;
+  }
+
+  let accessDeniedModalInstance = null;
+  const accessDeniedModalEl = document.getElementById('accessDeniedModal');
+  if (accessDeniedModalEl) {
+     accessDeniedModalInstance = new bootstrap.Modal(accessDeniedModalEl, {
+         backdrop: 'static', // Already set in HTML, but good to be explicit if needed
+         keyboard: false     // Already set in HTML
+     });
+  } else {
+      console.error("Access Denied Modal HTML not found on this page!");
+      // Fallback behavior if modal is missing: just redirect non-admins without modal.
+  }
+
+  const redirectToTasksBtn = document.getElementById('redirectToTasksBtn');
+  if (redirectToTasksBtn) {
+     redirectToTasksBtn.addEventListener('click', () => {
+         window.location.href = 'tasks.html'; // Assumes admin pages are in pages/ directory
+     });
+  }
+
+  try {
+    const { data: { user }, error: userError } = await window._supabase.auth.getUser();
+
+    if (userError || !user) {
+      console.log('Admin Page Guard: No user logged in or error fetching user. Redirecting to login.');
+      window.location.href = '../index.html'; // Adjust path if login page is different
+      return;
+    }
+
+    const { data: profile, error: profileError } = await window._supabase
+      .from('profiles')
+      .select('is_admin')
+      .eq('id', user.id)
+      .single();
+
+    if (profileError) {
+      console.error('Admin Page Guard: Error fetching profile. Denying access by default.', profileError);
+      if (accessDeniedModalInstance) {
+         accessDeniedModalInstance.show();
+      } else {
+         window.location.href = 'tasks.html'; // Fallback if modal isn't there
+      }
+      return;
+    }
+
+    const isAdmin = profile ? profile.is_admin : false;
+    localStorage.setItem('userIsAdmin', isAdmin.toString()); // Also update localStorage for consistency
+
+    if (!isAdmin) {
+      console.log('Admin Page Guard: User is not admin. Showing access denied modal.');
+      if (accessDeniedModalInstance) {
+         accessDeniedModalInstance.show();
+      } else {
+         window.location.href = 'tasks.html'; // Fallback
+      }
+      // Content remains hidden (or should be ensured hidden by modal logic)
+    } else {
+      console.log('Admin Page Guard: User is admin. Access granted.');
+      if (pageSpecificContent) {
+        pageSpecificContent.style.display = ''; // Show content
+      }
+    }
+  } catch (e) {
+    console.error('Admin Page Guard: Exception during access check. Denying access.', e);
+    if (accessDeniedModalInstance) {
+         accessDeniedModalInstance.show();
+    } else {
+         window.location.href = 'tasks.html'; // Fallback
+    }
+  }
+})();

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -46,12 +46,12 @@
         </div>
       </div>
     </div>
-    
-    <div id="welcomeMessage" class="container mt-3">Welcome!</div>
+    <div id="pageSpecificContent" style="display: none;">
+      <div id="welcomeMessage" class="container mt-3">Welcome!</div>
 
-    <div class="container mt-5">
-      <div class="row mt-4">
-        <div class="col-lg-4 col-md-6 mb-4">
+      <div class="container mt-5">
+        <div class="row mt-4">
+          <div class="col-lg-4 col-md-6 mb-4">
           <div class="card h-100">
             <div class="card-body">
               <div class="d-flex justify-content-between align-items-center mb-3">
@@ -162,12 +162,31 @@
       </div>
     </div>
   </div>
+  </div> <!-- Closing pageSpecificContent -->
+
+  <!-- Access Denied Modal -->
+  <div class="modal fade" id="accessDeniedModal" tabindex="-1" aria-labelledby="accessDeniedModalLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="accessDeniedModalLabel">Access Denied</h5>
+        </div>
+        <div class="modal-body">
+          <p>You do not have permission to view this page.</p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" id="redirectToTasksBtn">Go to My Tasks</button>
+        </div>
+      </div>
+    </div>
+  </div>
 
   <script src="../js/supabase-config.js"></script>
   <script type="module" src="../js/supabase-client.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
   <script type="module" src="../js/dashboard_check.js"></script> 
-  <script src="../js/main.js"></script> <!-- This is the new line -->
+  <script src="../js/main.js"></script>
   <script type="module" src="../js/i18n.js"></script>
+  <script type="module" src="../js/admin-page-guard.js"></script>
 </body>
 </html>

--- a/pages/properties.html
+++ b/pages/properties.html
@@ -46,10 +46,10 @@
         </div>
       </div>
     </div>
-    
-    <div class="container mt-4 p-4 properties-page-content">
-      <!-- Search and Action Buttons -->
-      <div class="d-flex justify-content-between align-items-center mb-4">
+    <div id="pageSpecificContent" style="display: none;">
+      <div class="container mt-4 p-4 properties-page-content">
+        <!-- Search and Action Buttons -->
+        <div class="d-flex justify-content-between align-items-center mb-4">
         <input type="text" placeholder="Search properties..." class="form-control w-50" data-i18n="propertiesPage.searchPlaceholder">
         <div class="d-flex align-items-center">
           <button class="btn btn-outline-secondary me-2" data-i18n="propertiesPage.filterButton"><i class="bi bi-funnel-fill me-1"></i>Filter</button>
@@ -162,5 +162,25 @@
   <script src="../js/lazy-load-properties.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcode-generator/1.4.4/qrcode.js" defer></script>
   <script src="../js/addProperty.js" defer></script>
+  </div> <!-- Closing pageSpecificContent -->
+
+  <!-- Access Denied Modal -->
+  <div class="modal fade" id="accessDeniedModal" tabindex="-1" aria-labelledby="accessDeniedModalLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="accessDeniedModalLabel">Access Denied</h5>
+        </div>
+        <div class="modal-body">
+          <p>You do not have permission to view this page.</p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" id="redirectToTasksBtn">Go to My Tasks</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="../js/admin-page-guard.js"></script>
 </body>
 </html>

--- a/pages/staff.html
+++ b/pages/staff.html
@@ -46,10 +46,10 @@
         </div>
       </div>
     </div>
-    
-    <div class="container mt-4 p-4 properties-page-content">
-      <!-- Filter Bar -->
-      <div class="d-flex flex-wrap justify-content-between align-items-center mb-4">
+    <div id="pageSpecificContent" style="display: none;">
+      <div class="container mt-4 p-4 properties-page-content">
+        <!-- Filter Bar -->
+        <div class="d-flex flex-wrap justify-content-between align-items-center mb-4">
         <div class="me-3 mb-2 flex-grow-1" style="max-width: 400px;">
           <input type="text" class="form-control" data-i18n="staffPage.filters.searchPlaceholder" placeholder="Search staff...">
         </div>
@@ -714,5 +714,25 @@
   <script src="../js/main.js"></script>
   <script type="module" src="../js/i18n.js"></script>
   <script src="../js/lazy-load-staff.js"></script>
+  </div> <!-- Closing pageSpecificContent -->
+
+  <!-- Access Denied Modal -->
+  <div class="modal fade" id="accessDeniedModal" tabindex="-1" aria-labelledby="accessDeniedModalLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="accessDeniedModalLabel">Access Denied</h5>
+        </div>
+        <div class="modal-body">
+          <p>You do not have permission to view this page.</p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" id="redirectToTasksBtn">Go to My Tasks</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="../js/admin-page-guard.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This feature introduces different experiences for admin and non-admin users:

1.  **Login Flow (`js/main.js`):**
    - After login, your `is_admin` status is fetched from your profile.
    - `is_admin` status is stored in `localStorage` for client-side UI updates.
    - Non-admin users are redirected to `pages/tasks.html`.
    - Admin users are redirected to `pages/dashboard.html` (or setup flow).
    - `userIsAdmin` is cleared from `localStorage` on sign-out.

2.  **Sidebar Link Hiding (`js/main.js`):**
    - A new function `updateSidebarForPermissions` runs on page load.
    - If `userIsAdmin` in `localStorage` is 'false', links to "Dashboard", "Properties", and "Staff" are hidden in the sidebar.

3.  **Admin Page Access Control (`js/admin-page-guard.js` & HTML pages):**
    - Created `js/admin-page-guard.js` to protect admin-only pages.
    - This script fetches `is_admin` directly from the database for an authoritative check.
    - Main content on admin pages (`dashboard.html`, `properties.html`, `staff.html`) is initially hidden via `<div id="pageSpecificContent" style="display: none;">`.
    - An "Access Denied" modal HTML snippet is defined and added to these admin pages.
    - If a non-admin attempts to access these pages:
        - The "Access Denied" modal is shown.
        - A button in the modal redirects to `tasks.html`.
    - If an admin accesses, page content is made visible.
    - If you are not logged in, you are redirected to the login page.