### PR TITLE
feat: Hide Company Settings on Account page for non-admins

### DIFF
--- a/js/account-details.js
+++ b/js/account-details.js
@@ -1,4 +1,13 @@
 document.addEventListener('DOMContentLoaded', async () => {
+    // Hide Company Settings for non-admins
+    const isAdminString = localStorage.getItem('userIsAdmin');
+    if (isAdminString === 'false') {
+      const companySettingsSection = document.getElementById('companySettingsSection');
+      if (companySettingsSection) {
+        companySettingsSection.style.display = 'none';
+      }
+    }
+
     // Main page elements
     const fullNameElement = document.getElementById('fullName');
     const emailAddressElement = document.getElementById('emailAddress');
@@ -133,6 +142,12 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Function to load and display company settings
     async function loadCompanySettings() {
+        // If user is not admin and section is already hidden by initial check, skip loading
+        if (isAdminString === 'false' && document.getElementById('companySettingsSection')?.style.display === 'none') {
+            console.log('Company settings section hidden for non-admin. Skipping loadCompanySettings.');
+            return;
+        }
+
         if (!window._supabase) {
             console.error('Supabase client is not available for company settings.');
             const companySettingsMessage = document.getElementById('companySettingsMessage');
@@ -590,3 +605,5 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
     }
 });
+
+[end of js/account-details.js]

--- a/pages/account.html
+++ b/pages/account.html
@@ -116,7 +116,7 @@
         </div>
       </div>
 
-      <div class="card mb-4">
+      <div class="card mb-4" id="companySettingsSection">
         <div class="card-header">
           <h5 class="mb-0" data-i18n="accountPage.company.title">Company Settings</h5>
         </div>


### PR DESCRIPTION
I modified `pages/account.html` to add an ID `companySettingsSection` to the div containing the Company Settings card.

I updated `js/account-details.js` to:
- Read the `userIsAdmin` status from localStorage on page load.
- If you are not an admin (`userIsAdmin === 'false'`), the `companySettingsSection` is hidden using `style.display = 'none'`.
- Added a check in `loadCompanySettings` to avoid running if the section is hidden.

This ensures non-admin users do not see the Company Settings section on their account page, aligning with role-based UI restrictions.