### PR TITLE
Add missing translation for profile loading text

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -357,5 +357,8 @@
     "optionGerman": "Deutsch",
     "selectLabel": "Sprache",
     "continueButton": "Weiter"
+  },
+  "loadingText": {
+    "profile": "Lade Profilinformationen..."
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -357,5 +357,8 @@
     "optionGerman": "German",
     "selectLabel": "Language",
     "continueButton": "Continue"
+  },
+  "loadingText": {
+    "profile": "Loading profile information..."
   }
 }


### PR DESCRIPTION
I added the `loadingText.profile` key to both en.json and de.json to resolve missing key warnings in your console related to i18next.

This change addresses the i18n warnings but does not fix the reported JavaScript syntax error (`Unexpected token 'of' at account-details.js:619`), which is likely the root cause of the Company Settings visibility bug. The syntax error appears to be in code outside the direct purview of the available files or at a line number exceeding the file's length, suggesting a build-time or runtime modification issue.