### PR TITLE
Fix: Remove duplicate variable declarations in account-details.js

### DIFF
--- a/js/account-details.js
+++ b/js/account-details.js
@@ -79,24 +79,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     const editProfileButton = document.getElementById('editProfileButton');
     const editProfileMessageElement = document.getElementById('editProfileMessage');
 
-    // Loading state elements
-    const fullNameElement = document.getElementById('fullName');
-    const emailAddressElement = document.getElementById('emailAddress');
-    const phoneNumberElement = document.getElementById('phoneNumber');
-    const languageDisplayElement = document.getElementById('languageDisplay');
-
-    // Modal elements
-    const editProfileModalElement = document.getElementById('editProfileModal');
-    const editProfileForm = document.getElementById('editProfileForm');
-    const modalFirstNameElement = document.getElementById('modalFirstName');
-    const modalLastNameElement = document.getElementById('modalLastName');
-    const modalEmailAddressElement = document.getElementById('modalEmailAddress');
-    const modalPhoneNumberElement = document.getElementById('modalPhoneNumber');
-    const modalLanguageSelectorElement = document.getElementById('modalLanguageSelector');
-    const saveProfileChangesButton = document.getElementById('saveProfileChanges');
-    const editProfileButton = document.getElementById('editProfileButton');
-    const editProfileMessageElement = document.getElementById('editProfileMessage');
-
     if (!fullNameElement || !emailAddressElement || !phoneNumberElement || !languageDisplayElement ||
         !editProfileModalElement || !editProfileForm || !modalFirstNameElement || !modalLastNameElement ||
         !modalEmailAddressElement || !modalPhoneNumberElement || !modalLanguageSelectorElement ||


### PR DESCRIPTION
Resolved a `SyntaxError: Identifier '...' has already been declared` by removing a duplicated block of `const` declarations for DOM elements (e.g., `fullNameElement`, `editProfileModalElement`).

These duplications were inadvertently introduced during a previous refactoring that added a try-catch block and a new admin-checking function. This commit ensures these element variables are declared only once within their scope.