### PR TITLE
Add favicon to all HTML pages.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="css/style.css">
+  <link rel="icon" href="assets/favicon.ico" type="image/x-icon">
   <style>
     /* Ensure full height for html and body for vh-100 to work on container-fluid */
     html, body {

--- a/pages/account.html
+++ b/pages/account.html
@@ -8,6 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="../css/style.css">
+  <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
 </head>
 <body>
   <div class="sidebar-overlay d-lg-none"></div> <!-- Add this line -->

--- a/pages/agency_setup_page.html
+++ b/pages/agency_setup_page.html
@@ -8,6 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="../css/style.css">
+  <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
 </head>
 <body class="bg-light">
   <div class="page-content-wrapper">

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -8,6 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="../css/style.css">
+  <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
 </head>
 <body>
   <div class="sidebar-overlay d-lg-none"></div> <!-- Add this line -->

--- a/pages/email-verified-success.html
+++ b/pages/email-verified-success.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <!-- Link to your custom stylesheet -->
   <link rel="stylesheet" href="../css/style.css">
+  <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
   <style>
     /* Basic centering styles */
     body, html {

--- a/pages/notifications.html
+++ b/pages/notifications.html
@@ -8,6 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="../css/style.css">
+  <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
 </head>
 <body>
   <div class="sidebar-overlay d-lg-none"></div> <!-- Add this line -->

--- a/pages/properties.html
+++ b/pages/properties.html
@@ -8,6 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="../css/style.css">
+  <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
 </head>
 <body>
   <div class="sidebar-overlay d-lg-none"></div> <!-- Add this line -->

--- a/pages/property-details.html
+++ b/pages/property-details.html
@@ -8,6 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="../css/style.css">
+  <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
 </head>
 <body>
   <div class="sidebar-overlay d-lg-none"></div>

--- a/pages/staff.html
+++ b/pages/staff.html
@@ -8,6 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="../css/style.css">
+  <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
 </head>
 <body>
   <div class="sidebar-overlay d-lg-none"></div> <!-- Add this line -->

--- a/pages/tasks.html
+++ b/pages/tasks.html
@@ -8,6 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="../css/style.css">
+  <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
 </head>
 <body>
   <div class="sidebar-overlay d-lg-none"></div>


### PR DESCRIPTION
This change adds the favicon.ico link to the <head> section of index.html and all HTML files in the pages/ directory to resolve the console error related to not finding the favicon.