### PR TITLE
Refactor: Conditionally fetch property count in dashboard_check.js

### DIFF
--- a/js/dashboard_check.js
+++ b/js/dashboard_check.js
@@ -30,7 +30,9 @@
       const user = data.session.user; // Get the user object
       initializeSignOutButton(); 
       fetchAndDisplayUserProfile(user); // New function call
-      fetchAndDisplayPropertyCount(user.id); // *** NEW CALL ***
+      if (window.location.pathname.includes('/dashboard.html')) {
+        fetchAndDisplayPropertyCount(user.id);
+      }
     }
   }
 


### PR DESCRIPTION
I modified `dashboard_check.js` so that the `fetchAndDisplayPropertyCount` function is only called if your current page is `dashboard.html`.

This prevents an error message in the console when `dashboard_check.js` runs on other pages like `account.html`, where the property count element is not present. The script's other functionalities, such as authentication checks and user profile display, remain active on all pages where it's included.