### PR TITLE
feat: Add profile image upload functionality to account page

### DIFF
--- a/pages/account.html
+++ b/pages/account.html
@@ -62,7 +62,8 @@
           <div class="row align-items-center">
             <div class="col-md-3 text-center mb-3 mb-md-0">
               <!-- Placeholder for Avatar -->
-              <i class="bi bi-person-circle fa-7x text-secondary"></i>
+              <img id="currentProfileImage" src="#" alt="User Avatar" class="img-fluid rounded-circle" style="width: 120px; height: 120px; object-fit: cover; display: none;">
+              <i id="defaultProfileIcon" class="bi bi-person-circle fa-7x text-secondary" style="display: block;"></i>
               <!-- Or an actual placeholder image: 
               <img src="https://via.placeholder.com/120" class="img-fluid rounded-circle" alt="User Avatar"> 
               -->
@@ -237,6 +238,12 @@
         <form id="editProfileForm">
           <!-- Alert for messages -->
           <div id="editProfileMessage" class="alert" style="display:none;" role="alert"></div>
+
+          <div class="mb-3">
+            <label for="profileImageUpload" class="form-label" data-i18n="accountPage.profile.profileImageLabel">Profile Image</label>
+            <input type="file" id="profileImageUpload" class="form-control" accept="image/*">
+            <img id="profileImagePreviewModal" src="#" alt="Profile Preview" class="img-thumbnail mt-2" style="max-width: 150px; max-height: 150px; display: none;">
+          </div>
 
           <div class="mb-3">
             <label for="modalFirstName" class="form-label">First Name</label>


### PR DESCRIPTION
This commit introduces the ability for you to upload and update your profile picture on the account settings page.

Key changes:
- Modified `pages/account.html`:
    - Added a file input and image preview to the 'Edit Profile' modal.
    - Updated the main profile view to display the current avatar or a default icon.
- Updated `js/account-details.js`:
    - Implemented logic to handle image selection and preview in the modal.
    - Added functionality to upload the selected image to the 'profile-images' Supabase storage bucket.
    - Ensured your `avatar_url` in the 'profiles' table is updated with the public URL of the uploaded image.
    - Updated functions to fetch and display your current avatar on the account page.
    - Included feedback messages for image upload progress and success/error states.

The feature assumes the existence of an `avatar_url` text column in the `profiles` table and a Supabase storage bucket named `profile-images`.