### PR TITLE
fix: Stabilize task creation and remove success alert

### DIFF
--- a/js/tasks-display.js
+++ b/js/tasks-display.js
@@ -573,7 +573,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Example: if (responseData && responseData.status === 'error') { throw new Error(responseData.message); }
 
 
-        alert('Task created successfully!'); // Replace with a nicer notification if available
+        // alert('Task created successfully!'); // Removed as per request
 
         const createTaskForm = document.getElementById('createTaskForm');
         if (createTaskForm) {


### PR DESCRIPTION
This commit finalizes the task creation flow by addressing several issues:

1.  **Resolves RLS recursion for `task_assignments`:**
    -   A SECURITY DEFINER SQL function (`is_task_assignable_by_user`) was introduced to check if you can assign a task.
    -   The INSERT RLS policy on `task_assignments` now uses this function, preventing previous "infinite recursion" errors (42P17).

2.  **Ensures `task_id` retrieval in Edge Function:**
    -   The `create-task` Edge Function now explicitly selects `task_id` (the PK of the `tasks` table) after inserting a new task.
    -   Added robust checks to ensure `task_id` is available before attempting to create an entry in `task_assignments`. This fixed 'null value in column "task_id"' errors (23502).

3.  **Corrects RLS `SELECT` policy for `tasks`:**
    -   Guidance was provided to update the `SELECT` RLS policy on the `tasks` table to allow creators/company owners to read tasks immediately after creation. This ensures the Edge Function can retrieve the `task_id`.

4.  **Removes Success Alert:**
    -   The `alert('Task created successfully!')` in `js/tasks-display.js` has been removed as per your request, providing a smoother UX flow.

Task creation should now be stable, secure, and user-friendly.