### PR TITLE
fix: Allow initial profile insert by user and set user_status

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -326,6 +326,8 @@ document.addEventListener('DOMContentLoaded', function () {
               profileDataToInsert.has_company_set_up = false; // Or rely on DB default
             }
 
+            profileDataToInsert.user_status = 'New'; // Set user_status for all new sign-ups
+
             const { error: profileError } = await window._supabase
               .from('profiles')
               .insert([profileDataToInsert])


### PR DESCRIPTION
This commit addresses an RLS issue that prevented newly signed-up users from inserting their initial record into the `profiles` table.

1.  **New RLS Policy (`schema_modifications.sql`):**
    *   Added a policy named "Profiles - Allow user to insert own initial
      profile" to the `profiles` table.
    *   This policy permits an authenticated user to insert a row into
      `profiles` if the `id` matches `auth.uid()`, `company_id` is NULL,
      and `is_admin`, `has_company_set_up`, and `user_status` fields
      match expected initial values (specifically `user_status = 'New'`).

2.  **Updated `js/main.js` (`handleSignUpFormSubmit`):**
    *   The logic for inserting the initial profile record after a
      successful `supabase.auth.signUp()` now explicitly sets
      `user_status: 'New'` in the data object being inserted.

These changes ensure that the initial profile creation step during user sign-up (for both agency and regular user types) complies with RLS, resolving the previous "new row violates row-level security policy" error (401 Unauthorized, SQL error 42501).