### PR TITLE
debug: Add console log for profile insertion data

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -328,6 +328,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
             profileDataToInsert.user_status = 'New'; // Set user_status for all new sign-ups
 
+            console.log('Attempting to insert profile:', JSON.stringify(profileDataToInsert, null, 2));
+
             const { error: profileError } = await window._supabase
               .from('profiles')
               .insert([profileDataToInsert])


### PR DESCRIPTION
To help diagnose an ongoing Row Level Security (RLS) issue where new profile insertions are failing with a 'violates row-level security policy' error, this commit adds a `console.log` statement in `js/main.js`.

The log occurs in the `handleSignUpFormSubmit` function (within the `signUpForm` event listener) immediately before the call to `supabase.from('profiles').insert([profileDataToInsert])`. It will output the exact `profileDataToInsert` object being constructed, allowing for a detailed comparison against the active RLS INSERT policies on the `profiles` table.

This is a temporary debugging measure to identify the mismatch causing the RLS violation during new user sign-up.