### PR TITLE
refactor: Ensure verification_code is not sent during initial profile…

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -302,8 +302,8 @@ document.addEventListener('DOMContentLoaded', function () {
             firstNameDebugMessage = " (Debug: first_name '" + data.user.user_metadata.first_name + "' seen in user_metadata)";
           }
 
-          // Generate 8-digit code and update profile
-          const generatedCode = Math.floor(10000000 + Math.random() * 90000000).toString();
+          // Generate 8-digit code and update profile // Commenting out generatedCode as it's no longer inserted
+          // const generatedCode = Math.floor(10000000 + Math.random() * 90000000).toString();
           const userId = data.user.id;
 
           try {
@@ -314,7 +314,7 @@ document.addEventListener('DOMContentLoaded', function () {
               id: userId,
               email: userEmail, // Make sure to use the email from auth response
               first_name: firstName, // This is from the form input
-              verification_code: generatedCode, // is_verified_by_code defaults to false in DB
+              // verification_code: generatedCode, // REMOVED: is_verified_by_code defaults to false in DB
               preferred_ui_language: typeof i18next !== 'undefined' ? i18next.language : 'en' // Default to 'en'
             };
 


### PR DESCRIPTION
… insert

This commit ensures that `js/main.js` does not include `verification_code` in the `profileDataToInsert` object during your initial sign-up process. This is to align with the RLS policy ("Profiles - Allow user to insert own initial profile" or the temporary "TEMP - Agency Admin Self Insert ONLY") which expects this field not to be sent by you, allowing the database's default value for `verification_code` to be applied.

This directly addresses the RLS violation error (401 Unauthorized, SQL error 42501) that occurred because `js/main.js` was previously still sending a client-generated `verification_code`, conflicting with the RLS policy that does not account for this field in its WITH CHECK clause for self-inserts.

The console.log for debugging `profileDataToInsert` remains in place for now. I made this change and am re-submitting to ensure clarity on the correct version.