### PR TITLE
fix(agency_setup.js): Align companyData field names with Edge Function

### DIFF
--- a/js/agency_setup.js
+++ b/js/agency_setup.js
@@ -161,16 +161,18 @@ document.addEventListener('DOMContentLoaded', function () {
 
                 const companyData = {
                     company_name: companyNameInput.value.trim(),
-                    company_address_street: companyAddressStreetInput.value.trim(),
-                    company_email: companyEmailInput.value.trim(),
-                    company_city: companyCityInput.value.trim(),
-                    company_state: companyStateInput.value.trim(),
-                    company_address_zip: companyPostCodeInput.value.trim(), // Renamed from companyPostCodeInput for consistency
-                    company_phone: companyPhoneInput.value.trim() || null,
-                    company_website: processedWebsiteUrl,
-                    company_tax_id: companyTaxIdInput.value.trim() || null,
+                    address_street: companyAddressStreetInput.value.trim(),
+                    email: companyEmailInput.value.trim(),
+                    address_city: companyCityInput.value.trim(),
+                    address_state: companyStateInput.value.trim(),
+                    address_postal_code: companyPostCodeInput.value.trim(),
+                    phone_number: companyPhoneInput.value.trim() || null,
+                    website_url: processedWebsiteUrl,
+                    tax_id: companyTaxIdInput.value.trim() || null,
                     company_logo_url: companyLogoUrl
                 };
+
+                console.log('[agency_setup.js] Corrected companyData being sent:', JSON.stringify(companyData, null, 2));
 
                 // Invoke Supabase Edge Function
                 const { data: functionResponse, error: functionError } = await window._supabase.functions.invoke('save-company-details', {


### PR DESCRIPTION
This commit modifies `js/agency_setup.js` to correct the field names in the `companyData` object that is sent to the `save-company-details` Supabase Edge Function.

Previously, `js/agency_setup.js` was sending field names like `company_address_street`, `company_email`, etc., while the Edge Function's `CompanyData` interface expected `address_street`, `email`, etc. This mismatch caused the Edge Function to return a `400 Bad Request` error due to its validation logic for required fields not finding the expected keys.

The following field names in the `companyData` object within `js/agency_setup.js` have been updated to match the Edge Function:
- `company_address_street` -> `address_street`
- `company_email` -> `email`
- `company_city` -> `address_city`
- `company_state` -> `address_state`
- `company_address_zip` -> `address_postal_code`
- `company_phone` -> `phone_number`
- `company_website` -> `website_url`
- `company_tax_id` -> `tax_id`

A `console.log` has also been added to `js/agency_setup.js` to display the corrected `companyData` object just before it's sent to the Edge Function, aiding in future debugging if needed.

This change should resolve the `400 Bad Request` error encountered during the submission of the agency setup form.