### PR TITLE
feat(staff): Optimize fetching of assigned task counts

### DIFF
--- a/assets/STAFF_ACTIVATION_IMPROVEMENTS.md
+++ b/assets/STAFF_ACTIVATION_IMPROVEMENTS.md
@@ -1,0 +1,69 @@
+# Staff Account Activation & Password Setting Improvements
+
+## Current Situation (Company Code Flow for Staff Activation)
+
+The current flow for a new staff member (whose profile is typically pre-created by an admin with `user_status: 'New'`) to activate their account and set their password is as follows:
+
+1.  **Admin Action:** Admin creates a staff profile (e.g., `email: staff@example.com`, `user_status: 'New'`, `company_id: XYZ`, `is_admin: false`). It's assumed an `auth.users` record is also created for this staff member, or the system can link to an existing one if the email matches.
+2.  **Staff Action (UI):**
+    *   Staff member goes to the sign-up/sign-in page.
+    *   Clicks "I have a Company Code".
+    *   Enters the 8-digit Company Code.
+    *   Enters their email address.
+    *   Enters their desired new password (and confirms it).
+3.  **Client-Side Logic (`js/main.js`):**
+    *   Validates the Company Code against the `companies` table (via RPC to `validate_company_code`).
+    *   Validates the staff member's email against the `profiles` table (checks for existence, correct `company_id`, and `user_status = 'New'`).
+    *   If both are valid, it attempts to set/update the user's password using `supabase.auth.updateUser({ password: newPassword })`.
+    *   If password update is successful, it updates `profiles.user_status` to 'Active'.
+
+## Potential Issue with Current `supabase.auth.updateUser()`
+
+The `supabase.auth.updateUser()` function on the client-side typically requires that the user for whom the password is being updated has an active, authenticated JWT session that the Supabase JS client is aware of.
+
+For a brand new staff member activating their account:
+*   If their `auth.users` record was just created (e.g., by an admin inviting them or creating them directly via admin SDK) and they haven't logged in before, they might not have an active session that `updateUser()` recognizes as valid for them to change their *own* password.
+*   The flow relies on the session context after email verification (if that's part of the prerequisite) and the company code/email validation steps being sufficient for Supabase to authorize this specific user to update their password.
+
+While this flow appears to be working in current testing, it might encounter edge cases or prove less robust than a backend-controlled password setting mechanism, especially if the user's session state is not perfectly established before this call.
+
+## Recommended Improvement: Edge Function for Password Setting
+
+A more robust and secure approach for setting a user's password for the first time (or for password resets) is to use a Supabase Edge Function that operates with elevated privileges (`service_role`).
+
+**Proposed Flow:**
+
+1.  **Admin Action & User Metadata:**
+    *   When an admin creates a staff member, an `auth.users` record should be created for them (e.g., using `supabase.auth.admin.createUser(...)` on the backend if not already handled). This ensures an `auth.users.id` exists.
+    *   This `auth.users.id` should be stored in the corresponding `public.profiles` record (e.g., in an `auth_user_id` column if it's different from `profiles.id`, or `profiles.id` is used directly as the FK to `auth.users.id`).
+
+2.  **Staff Action (UI):** Same as current: enter company code, email, new password.
+
+3.  **Client-Side Logic (`js/main.js`):**
+    *   Validate Company Code (as currently done via RPC).
+    *   Validate staff member's email against `profiles` (as currently done).
+    *   **Instead of calling `supabase.auth.updateUser()` directly:**
+        *   Call a new Supabase Edge Function, e.g., `activate-staff-account`.
+        *   Send necessary identifiers (like `profile.id` or `profile.auth_user_id`) and the `new_password` in the request body to this Edge Function.
+
+4.  **New Edge Function (`activate-staff-account` - uses `service_role`):**
+    *   **Authentication:** The function should still be callable only by an authenticated user (the staff member who has passed the initial company code/email checks and has a temporary session or is identified by the client).
+    *   **Input:** Receives `user_id_to_activate` (this would be the `auth.users.id` for the staff member) and `new_password`.
+    *   **Verification (Optional but good):** The function could re-verify that the calling user (from `context.auth.uid`) matches the `user_id_to_activate` if they are supposed to be the same, or that the calling user has some permission to activate this account (though for self-activation, they'd match). For this flow, the client has already done the company code/email validation, so the main job is the privileged password update.
+    *   **Password Update:** Uses the `service_role` Supabase client to execute:
+        ```typescript
+        const { data: updatedUser, error: updateUserError } = await supabaseAdminClient.auth.admin.updateUserById(
+          userIdToActivate, // This is the auth.users.id of the staff member
+          { password: new_password }
+        );
+        ```
+    *   **Profile Update:** If password update is successful, it updates `public.profiles.user_status` to 'Active' for the corresponding profile ID.
+    *   **Return:** Success or error response.
+
+**Advantages of the Edge Function Approach:**
+
+*   **Security:** The critical `updateUserById` operation (which requires admin privileges) is performed in a trusted backend environment.
+*   **Robustness:** Less reliant on the nuances of client-side session state for a user who is essentially activating their account.
+*   **Clear Separation of Concerns:** Client handles initial validation and UI; backend handles privileged operations.
+
+This approach provides a more secure and reliable mechanism for the final step of staff account activation.


### PR DESCRIPTION
This commit refactors `js/staff-management.js` to improve the performance of fetching staff data along with their assigned task counts.

Previously, the `fetchStaffForCompany` function first fetched all staff profiles and then iterated through them, making an individual RPC call to `get_assigned_tasks_count` for each staff member. This resulted in an N+1 query problem, potentially slowing down page load for agencies with many staff.

Changes:

1.  **New SQL Function (`get_staff_for_company_with_task_counts`):**
    *   A new PostgreSQL function (previously added to
      `schema_modifications.sql`) named
      `public.get_staff_for_company_with_task_counts(p_company_id UUID)`
      is now used.
    *   This function efficiently retrieves all staff members for a given
      company and includes their assigned task counts (calculated via a
      join with a subquery on `task_assignments`) in a single database query.

2.  **Updated `js/staff-management.js` (`fetchStaffForCompany`):**
    *   The `fetchStaffForCompany` function has been entirely rewritten to
      make a single RPC call to the new
      `get_staff_for_company_with_task_counts` SQL function.
    *   The loop making individual RPC calls for task counts has been removed.
    *   The `adminUserId` parameter was removed from `fetchStaffForCompany`
      as it was no longer needed for this specific optimized query, and
      call sites were updated.
    *   Error handling for the RPC call is maintained.

This change significantly reduces the number of database roundtrips required to load the staff list, leading to better performance and scalability.

You are advised that after applying these changes and confirming functionality, the old SQL function
`public.get_assigned_tasks_count(staff_user_id UUID)` is no longer used by this script and can be dropped from the database. The `create-initial-profile` Edge Function is also now redundant due to the trigger-based profile setup and can be removed.