### PR TITLE
fix(staff-management.js): Correct SyntaxError in renderStaffTable

### DIFF
--- a/js/staff-management.js
+++ b/js/staff-management.js
@@ -154,7 +154,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                     <button class="btn btn-link text-warning p-0 edit-staff-btn" data-staff-id="${staff.id}" title="Edit Profile" data-i18n="[title]staffPage.table.actions.editProfileTooltip"><i class="bi bi-pencil-square"></i></button>
                 </td>
             `;
-            `;
         });
         // Re-apply i18n for dynamically added tooltips if necessary
         if (window.i18next && typeof window.updateUI === 'function') {


### PR DESCRIPTION
This commit fixes an `Uncaught SyntaxError: Unexpected identifier '$'` in `js/staff-management.js`.

The error was caused by a stray backtick and semicolon on an extra line immediately following the multi-line template literal assignment to `row.innerHTML` within the `renderStaffTable` function. This extraneous line has been removed.

This fix should allow `js/staff-management.js` to execute correctly, enabling event listeners (such as for the "Add New Staff Member" button) and other JavaScript-driven functionalities on the staff management page.