### PR TITLE
Fix: Resolve staff page errors and add missing translations

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -327,11 +327,35 @@
       },
       "view": {
         "title": "View Staff Details",
-        "bodyPlaceholder": "Staff details will be displayed here."
+        "bodyPlaceholder": "Staff details will be displayed here.",
+        "fields": {
+          "name": "Name",
+          "email": "Email",
+          "role": "Role",
+          "status": "Status",
+          "assignedTasks": "Assigned Tasks"
+        }
       },
       "edit": {
         "title": "Edit Staff Member",
-        "bodyPlaceholder": "Form for editing staff member will be here."
+        "bodyPlaceholder": "Form for editing staff member will be here.",
+        "form": {
+          "firstNameLabel": "First Name",
+          "lastNameLabel": "Last Name",
+          "emailLabel": "Email",
+          "emailHelp": "We'll never share your email with anyone else.",
+          "roleLabel": "Role",
+          "role": {
+            "selectPlaceholder": "Select a role...",
+            "electrician": "Electrician",
+            "plumber": "Plumber",
+            "cleaner": "Cleaner"
+          },
+          "statusLabel": "Status",
+          "status": {
+            "selectPlaceholder": "Select a status..."
+          }
+        }
       }
     }
   },

--- a/supabase/migrations/20240514103000_create_staff_task_count_rpc.sql
+++ b/supabase/migrations/20240514103000_create_staff_task_count_rpc.sql
@@ -1,0 +1,85 @@
+-- supabase/migrations/YYYYMMDDHHMMSS_create_staff_task_count_rpc.sql
+
+CREATE OR REPLACE FUNCTION get_staff_for_company_with_task_counts(p_company_id UUID)
+RETURNS TABLE (
+    id UUID,
+    first_name TEXT,
+    last_name TEXT,
+    email TEXT,
+    user_role TEXT,
+    user_status TEXT,
+    assigned_tasks_count BIGINT
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    -- Check if the tasks table and assigned_to_user_id column exist
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'tasks'
+    ) THEN
+        -- If tasks table doesn't exist, return profiles without task counts
+        RETURN QUERY
+        SELECT
+            p.id,
+            p.first_name,
+            p.last_name,
+            p.email,
+            p.user_role,
+            p.user_status,
+            0::BIGINT AS assigned_tasks_count -- Return 0 for task count
+        FROM
+            profiles p
+        WHERE
+            p.company_id = p_company_id;
+    ELSIF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'tasks' AND column_name = 'assigned_to_user_id'
+    ) THEN
+        -- If assigned_to_user_id column doesn't exist in tasks table, return profiles without task counts
+        RAISE WARNING 'Column assigned_to_user_id does not exist in tasks table. Returning 0 for task counts.';
+        RETURN QUERY
+        SELECT
+            p.id,
+            p.first_name,
+            p.last_name,
+            p.email,
+            p.user_role,
+            p.user_status,
+            0::BIGINT AS assigned_tasks_count
+        FROM
+            profiles p
+        WHERE
+            p.company_id = p_company_id;
+    ELSE
+        -- If tasks table and column exist, proceed with the join
+        RETURN QUERY
+        SELECT
+            p.id,
+            p.first_name,
+            p.last_name,
+            p.email,
+            p.user_role,
+            p.user_status,
+            COUNT(t.id) AS assigned_tasks_count
+        FROM
+            profiles p
+        LEFT JOIN
+            tasks t ON p.id = t.assigned_to_user_id
+        WHERE
+            p.company_id = p_company_id
+        GROUP BY
+            p.id, p.first_name, p.last_name, p.email, p.user_role, p.user_status;
+    END IF;
+END;
+$$;
+
+-- Grant execution rights to the authenticated role (or any relevant role)
+-- This allows the function to be called by your application users.
+GRANT EXECUTE ON FUNCTION get_staff_for_company_with_task_counts(UUID) TO authenticated;
+-- If you have a service_role or other specific roles that need to execute this, grant them as well.
+-- GRANT EXECUTE ON FUNCTION get_staff_for_company_with_task_counts(UUID) TO service_role;
+
+COMMENT ON FUNCTION get_staff_for_company_with_task_counts(UUID) IS
+'Retrieves staff members for a given company ID with a count of their assigned tasks.
+If the tasks table or the assigned_to_user_id column does not exist, it returns staff with 0 task count and raises a warning.';


### PR DESCRIPTION
This commit addresses two main issues on the staff.html page:

1.  Creates the Supabase RPC function `get_staff_for_company_with_task_counts`. The previous 404 error for this function call prevented staff data from loading. The new SQL function, stored in `supabase/migrations/20240514103000_create_staff_task_count_rpc.sql`, retrieves staff members for a company and includes a count of their assigned tasks. It also handles cases where the 'tasks' table or 'assigned_to_user_id' column might not exist, ensuring resilience.

2.  Adds missing i18next translation keys to `locales/en.json`. Numerous "missingKey" errors were appearing in the console for modal fields on the staff page. The necessary keys under `staffPage.modals.view.fields` and `staffPage.modals.edit.form` have been added with English placeholders.

After applying the SQL migration and deploying these changes, the staff page should load correctly, display staff task counts, and show appropriate labels in view/edit modals without console errors.