### PR TITLE
Feat: Display 'Owner' status for staff and add debug logs

### DIFF
--- a/js/staff-management.js
+++ b/js/staff-management.js
@@ -131,16 +131,26 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         staffList.forEach(staff => {
             const row = staffTableBody.insertRow();
-            const status = staff.user_status || 'N/A';
-            let statusBadgeClass = 'badge-custom-gray'; // Default for N/A or other statuses
-            if (status === 'Active') {
+            let statusText = staff.user_status || 'N/A';
+            let statusBadgeClass = 'badge-custom-gray'; // Default
+
+            console.log('[renderStaffTable] Processing staff:', staff.id, 'is_owner value:', staff.is_owner, 'Type:', typeof staff.is_owner);
+            if (staff.is_owner) {
+                console.log('[renderStaffTable] Staff member IS owner. Setting status to Owner.');
+                statusText = 'Owner'; // Consider i18n: staffPage.status.owner
+                statusBadgeClass = 'badge-custom-purple';
+            } else {
+                console.log('[renderStaffTable] Staff member is NOT owner or is_owner is not true. Proceeding with normal status.');
+                if (statusText === 'Active') {
                 statusBadgeClass = 'badge-custom-green';
-            } else if (status === 'New') { // Assuming 'New' is a possible status
+                statusBadgeClass = 'badge-custom-green';
+            } else if (statusText === 'New') {
                 statusBadgeClass = 'badge-custom-blue';
-            } else if (status === 'Invited') { // Example for another status
-                statusBadgeClass = 'badge-custom-yellow'; // You'd need to define this style
-            } else if (status === 'Inactive') {
+            } else if (statusText === 'Invited') {
+                statusBadgeClass = 'badge-custom-yellow';
+            } else if (statusText === 'Inactive') {
                 statusBadgeClass = 'badge-custom-gray';
+            }
             }
 
             row.innerHTML = `
@@ -148,7 +158,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 <td>${staff.first_name || ''} ${staff.last_name || ''}</td>
                 <td>${staff.user_role || 'N/A'}</td>
                 <td class="staff-col-assigned-tasks">${staff.assigned_tasks_count !== undefined ? staff.assigned_tasks_count : 'N/A'}</td>
-                <td class="staff-col-status"><span class="badge-custom-base ${statusBadgeClass}">${status}</span></td>
+                <td class="staff-col-status"><span class="badge-custom-base ${statusBadgeClass}">${statusText}</span></td>
                 <td>
                     <button class="btn btn-link text-primary p-0 me-2 view-staff-btn" data-staff-id="${staff.id}" title="View Details" data-i18n="[title]staffPage.table.actions.viewDetailsTooltip"><i class="bi bi-eye-fill"></i></button>
                     <button class="btn btn-link text-warning p-0 edit-staff-btn" data-staff-id="${staff.id}" title="Edit Profile" data-i18n="[title]staffPage.table.actions.editProfileTooltip"><i class="bi bi-pencil-square"></i></button>
@@ -224,13 +234,27 @@ document.addEventListener('DOMContentLoaded', async () => {
                 document.getElementById('viewStaffRole').textContent = staffMember.user_role || 'N/A';
 
                 const statusEl = document.getElementById('viewStaffStatus');
-                const status = staffMember.user_status || 'N/A';
+                let statusText = staffMember.user_status || 'N/A';
                 let badgeClass = 'badge-custom-gray'; // Default
-                if (status === 'Active') badgeClass = 'badge-custom-green';
-                else if (status === 'New') badgeClass = 'badge-custom-blue';
-                else if (status === 'Invited') badgeClass = 'badge-custom-yellow';
-                else if (status === 'Inactive') badgeClass = 'badge-custom-gray';
-                statusEl.innerHTML = `<span class="badge-custom-base ${badgeClass}">${status}</span>`;
+
+                console.log('[viewStaffModal] Processing staffMember:', staffMember.id, 'is_owner value:', staffMember.is_owner, 'Type:', typeof staffMember.is_owner);
+                if (staffMember.is_owner) {
+                    console.log('[viewStaffModal] Staff member IS owner for modal. Setting status to Owner.');
+                    statusText = 'Owner'; // Consider i18n: staffPage.status.owner
+                    badgeClass = 'badge-custom-purple';
+                } else {
+                    console.log('[viewStaffModal] Staff member is NOT owner or is_owner is not true for modal. Proceeding with normal status.');
+                    if (statusText === 'Active') {
+                    badgeClass = 'badge-custom-green';
+                } else if (statusText === 'New') {
+                    badgeClass = 'badge-custom-blue';
+                } else if (statusText === 'Invited') {
+                    badgeClass = 'badge-custom-yellow';
+                } else if (statusText === 'Inactive') {
+                    badgeClass = 'badge-custom-gray';
+                }
+                }
+                statusEl.innerHTML = `<span class="badge-custom-base ${badgeClass}">${statusText}</span>`;
 
                 document.getElementById('viewStaffAssignedTasks').textContent = staffMember.assigned_tasks_count !== undefined ? staffMember.assigned_tasks_count : 'N/A';
 

--- a/supabase/migrations/20240514103000_create_staff_task_count_rpc.sql
+++ b/supabase/migrations/20240514103000_create_staff_task_count_rpc.sql
@@ -1,4 +1,4 @@
--- supabase/migrations/YYYYMMDDHHMMSS_create_staff_task_count_rpc.sql
+-- supabase/migrations/20240514103000_create_staff_task_count_rpc.sql
 
 CREATE OR REPLACE FUNCTION get_staff_for_company_with_task_counts(p_company_id UUID)
 RETURNS TABLE (
@@ -8,17 +8,40 @@ RETURNS TABLE (
     email TEXT,
     user_role TEXT,
     user_status TEXT,
-    assigned_tasks_count BIGINT
+    assigned_tasks_count BIGINT,
+    is_owner BOOLEAN -- New column
 )
 LANGUAGE plpgsql
 AS $$
 BEGIN
-    -- Check if the tasks table and assigned_to_user_id column exist
+    -- Check if the companies table exists
     IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'companies'
+    ) THEN
+        RAISE WARNING 'Companies table not found. Cannot determine ownership. Returning staff without owner status.';
+        -- Fallback to original logic if companies table is missing
+        -- Return is_owner as FALSE in this case.
+         RETURN QUERY
+            SELECT
+                p.id,
+                p.first_name,
+                p.last_name,
+                p.email,
+                p.user_role,
+                p.user_status,
+                0::BIGINT AS assigned_tasks_count,
+                FALSE AS is_owner -- Default is_owner to FALSE
+            FROM
+                profiles p
+            WHERE
+                p.company_id = p_company_id;
+    -- Check if the tasks table exists
+    ELSIF NOT EXISTS (
         SELECT 1 FROM information_schema.tables
         WHERE table_schema = 'public' AND table_name = 'tasks'
     ) THEN
-        -- If tasks table doesn't exist, return profiles without task counts
+        RAISE WARNING 'Tasks table not found. Returning 0 for task counts.';
         RETURN QUERY
         SELECT
             p.id,
@@ -27,16 +50,19 @@ BEGIN
             p.email,
             p.user_role,
             p.user_status,
-            0::BIGINT AS assigned_tasks_count -- Return 0 for task count
+            0::BIGINT AS assigned_tasks_count,
+            (p.id = c.owner_id) AS is_owner
         FROM
             profiles p
+        JOIN
+            companies c ON p.company_id = c.id -- Join companies table
         WHERE
             p.company_id = p_company_id;
+    -- Check if assigned_to_user_id column exists in tasks table
     ELSIF NOT EXISTS (
         SELECT 1 FROM information_schema.columns
         WHERE table_schema = 'public' AND table_name = 'tasks' AND column_name = 'assigned_to_user_id'
     ) THEN
-        -- If assigned_to_user_id column doesn't exist in tasks table, return profiles without task counts
         RAISE WARNING 'Column assigned_to_user_id does not exist in tasks table. Returning 0 for task counts.';
         RETURN QUERY
         SELECT
@@ -46,13 +72,16 @@ BEGIN
             p.email,
             p.user_role,
             p.user_status,
-            0::BIGINT AS assigned_tasks_count
+            0::BIGINT AS assigned_tasks_count,
+            (p.id = c.owner_id) AS is_owner
         FROM
             profiles p
+        JOIN
+            companies c ON p.company_id = c.id -- Join companies table
         WHERE
             p.company_id = p_company_id;
     ELSE
-        -- If tasks table and column exist, proceed with the join
+        -- If all tables and columns exist, proceed with the full join logic
         RETURN QUERY
         SELECT
             p.id,
@@ -61,25 +90,26 @@ BEGIN
             p.email,
             p.user_role,
             p.user_status,
-            COUNT(t.id) AS assigned_tasks_count
+            COUNT(t.id) AS assigned_tasks_count,
+            (p.id = c.owner_id) AS is_owner -- Determine if the profile user is the company owner
         FROM
             profiles p
+        JOIN
+            companies c ON p.company_id = c.id -- Join companies table to check owner_id
         LEFT JOIN
             tasks t ON p.id = t.assigned_to_user_id
         WHERE
             p.company_id = p_company_id
         GROUP BY
-            p.id, p.first_name, p.last_name, p.email, p.user_role, p.user_status;
+            p.id, p.first_name, p.last_name, p.email, p.user_role, p.user_status, c.owner_id; -- Add c.owner_id to GROUP BY
     END IF;
 END;
 $$;
 
 -- Grant execution rights to the authenticated role (or any relevant role)
--- This allows the function to be called by your application users.
 GRANT EXECUTE ON FUNCTION get_staff_for_company_with_task_counts(UUID) TO authenticated;
--- If you have a service_role or other specific roles that need to execute this, grant them as well.
--- GRANT EXECUTE ON FUNCTION get_staff_for_company_with_task_counts(UUID) TO service_role;
 
 COMMENT ON FUNCTION get_staff_for_company_with_task_counts(UUID) IS
-'Retrieves staff members for a given company ID with a count of their assigned tasks.
-If the tasks table or the assigned_to_user_id column does not exist, it returns staff with 0 task count and raises a warning.';
+'Retrieves staff members for a given company ID with a count of their assigned tasks and an is_owner flag.
+If the tasks table or the assigned_to_user_id column does not exist, it returns staff with 0 task count.
+If the companies table doesn''t exist, is_owner will be false and a warning raised.';


### PR DESCRIPTION
This commit introduces changes to display a special "Owner" status for the company owner on the staff page.

Changes include:
1.  Modified the `get_staff_for_company_with_task_counts` RPC function (in `supabase/migrations/20240514103000_create_staff_task_count_rpc.sql`) to return an `is_owner` boolean flag. This flag is true if the staff member's ID matches the `owner_id` in the `companies` table.

2.  Updated `js/staff-management.js`:
    - Modified `renderStaffTable` and the view modal logic to check the `is_owner` flag. If true, the status is displayed as "Owner" with a distinct badge class (`badge-custom-purple`).
    - Added detailed console logging around the `is_owner` checks in both `renderStaffTable` and the view modal logic to help diagnose why the "Owner" status might not be displaying as expected in your environment.

This change is intended to allow you to access the new debugging logs to further investigate the display of the "Owner" status.