### PR TITLE
Style: Update 'Add New Staff Member' button text to '+ Staff'

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -272,7 +272,7 @@
       "statusInactive": "Status: Inaktiv"
     },
     "buttons": {
-      "addNewStaff": "Neuen Mitarbeiter hinzufügen"
+      "addNewStaff": "+ Mitarbeiter"
     },
     "table": {
       "header": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -272,7 +272,7 @@
       "statusInactive": "Status: Inactive"
     },
     "buttons": {
-      "addNewStaff": "Add New Staff Member"
+      "addNewStaff": "+ Staff"
     },
     "table": {
       "header": {

--- a/pages/staff.html
+++ b/pages/staff.html
@@ -55,7 +55,7 @@
           <input type="text" class="form-control" data-i18n="staffPage.filters.searchPlaceholder" placeholder="Search staff...">
         </div>
         <div class="ms-auto mb-2">
-          <button class="btn btn-primary" id="addNewStaffMemberBtn" type="button" data-i18n="staffPage.buttons.addNewStaff">Add New Staff Member</button>
+          <button class="btn btn-primary" id="addNewStaffMemberBtn" type="button" data-i18n="staffPage.buttons.addNewStaff">+ Staff</button>
         </div>
       </div>
       <!-- End Filter Bar -->


### PR DESCRIPTION
This commit updates the text and internationalization for the button used to add new staff members on the staff page.

Changes:
- The fallback text in `pages/staff.html` for the button with ID `addNewStaffMemberBtn` has been changed from "Add New Staff Member" to "+ Staff".
- The English translation for the i18n key `staffPage.buttons.addNewStaff` in `locales/en.json` has been updated to "+ Staff".
- The German translation for the same key in `locales/de.json` has been updated to "+ Mitarbeiter".

This provides a more concise button label as per your request.