### PR TITLE
Feat: Implement 'Add New Staff via Invitation' flow

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,5 @@
+// supabase/functions/_shared/cors.ts
+export const corsHeaders = {
+  'Access-Control-Allow-Origin': '*', // Or your specific domain
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}

--- a/supabase/functions/invite-staff-member/index.ts
+++ b/supabase/functions/invite-staff-member/index.ts
@@ -1,0 +1,158 @@
+// supabase/functions/invite-staff-member/index.ts
+import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders } from '../_shared/cors.ts'
+
+console.log('Edge Function `invite-staff-member` booting up');
+
+serve(async (req: Request) => {
+  // This is needed if you're planning to invoke your function from a browser.
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    const supabaseAdmin = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    );
+
+    const { email, firstName, lastName, role } = await req.json();
+    console.log('Received request to invite staff:', { email, firstName, lastName, role });
+
+    if (!email || !firstName || !lastName || !role) {
+      return new Response(JSON.stringify({ error: 'Missing required fields: email, firstName, lastName, role' }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 400,
+      });
+    }
+
+    // Get the authenticated user (the admin performing the action)
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+        console.error('No Authorization header found');
+        return new Response(JSON.stringify({ error: 'User not authenticated' }), {
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+            status: 401,
+        });
+    }
+    const jwt = authHeader.replace('Bearer ', '');
+    const { data: { user: invokerUser }, error: userError } = await supabaseAdmin.auth.getUser(jwt);
+
+    if (userError || !invokerUser) {
+      console.error('Error fetching invoker user or user not found:', userError);
+      return new Response(JSON.stringify({ error: 'Failed to identify inviting user.' }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 401,
+      });
+    }
+    console.log('Invoker user ID:', invokerUser.id);
+
+    // Check if the invoker is an admin and get their company_id
+    const { data: adminProfile, error: profileError } = await supabaseAdmin
+      .from('profiles')
+      .select('company_id, is_admin')
+      .eq('id', invokerUser.id)
+      .single();
+
+    if (profileError) {
+      console.error('Error fetching admin profile:', profileError);
+      return new Response(JSON.stringify({ error: 'Could not verify admin status.' }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 500,
+      });
+    }
+
+    if (!adminProfile) {
+        console.error('Admin profile not found for invoker ID:', invokerUser.id);
+        return new Response(JSON.stringify({ error: 'Admin profile not found.' }), {
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+            status: 403, // Forbidden, as the user might be valid but not an admin profile
+        });
+    }
+
+    console.log('Admin profile fetched:', adminProfile);
+
+    if (!adminProfile.is_admin) {
+      console.warn('Invoker is not an admin:', invokerUser.id);
+      return new Response(JSON.stringify({ error: 'User does not have admin privileges to invite staff.' }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 403, // Forbidden
+      });
+    }
+
+    if (!adminProfile.company_id) {
+      console.error('Admin inviting staff does not have a company_id:', invokerUser.id);
+      return new Response(JSON.stringify({ error: 'Admin is not associated with a company.' }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 400, // Bad Request or 500, as admin setup is incomplete
+      });
+    }
+    console.log('Admin company ID:', adminProfile.company_id);
+
+    // Invite the new staff member
+    const { data: inviteResponse, error: inviteError } = await supabaseAdmin.auth.admin.inviteUserByEmail(
+      email,
+      {
+        data: {
+          first_name: firstName,
+          last_name: lastName,
+          user_role: role,
+          company_id: adminProfile.company_id,
+          is_admin: false, // Staff members are not admins by default
+          // user_status: 'Invited', // Supabase handles the initial state; trigger can refine if needed
+                                  // raw_app_meta_data in the trigger will contain this 'data' object
+        },
+        // redirectTo: 'https://your-app.com/set-password-page' // Optional: specify a redirect URL after email confirmation
+      }
+    );
+
+    if (inviteError) {
+      console.error('Error inviting user:', inviteError);
+      // Check for specific errors, e.g., user already registered
+      if (inviteError.message.includes('User already registered')) {
+         return new Response(JSON.stringify({ error: 'This email is already registered. If they are part of your company, they should appear in the staff list. If not, please use a different email.' }), {
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          status: 409, // Conflict
+        });
+      }
+      return new Response(JSON.stringify({ error: `Failed to send invitation: ${inviteError.message}` }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 500,
+      });
+    }
+
+    console.log('Invitation sent successfully to:', email, 'Response:', inviteResponse);
+    // The inviteResponse for inviteUserByEmail contains the invited user object.
+    // We don't strictly need to return it all, but can confirm success.
+    return new Response(JSON.stringify({ message: 'Invitation sent successfully!', userId: inviteResponse.user?.id }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 200,
+    });
+
+  } catch (error) {
+    console.error('Unexpected error in invite-staff-member function:', error);
+    return new Response(JSON.stringify({ error: error.message || 'An unexpected error occurred.' }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 500,
+    });
+  }
+})
+
+/*
+To test locally (after `supabase start`):
+1. Ensure you have an admin user. Get their JWT.
+2. Run:
+supabase functions serve invite-staff-member --no-verify-jwt
+
+curl -i --location --request POST 'http://localhost:54321/functions/v1/invite-staff-member' --header 'Authorization: Bearer YOUR_ADMIN_USER_JWT' --header 'Content-Type: application/json' --data '{
+    "email": "newstaff@example.com",
+    "firstName": "New",
+    "lastName": "Staff",
+    "role": "Electrician"
+}'
+
+If using --no-verify-jwt for serving, the JWT isn't checked by Supabase,
+but the function still tries to get user from it.
+For actual deployment, JWT verification is handled by Supabase gateway.
+*/

--- a/supabase/migrations/20240514103100_create_auth_users_trigger.sql
+++ b/supabase/migrations/20240514103100_create_auth_users_trigger.sql
@@ -1,0 +1,90 @@
+-- Function to create a profile for a new user from auth.users
+-- This function assumes metadata (first_name, last_name, user_role, company_id, is_admin, user_status)
+-- is passed during user invitation via `inviteUserByEmail` in the `data` property.
+
+CREATE OR REPLACE FUNCTION public.handle_new_invited_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER -- Necessary to write to public.profiles from auth context
+AS $$
+DECLARE
+  metadata JSONB;
+  profile_company_id UUID;
+  profile_user_role TEXT;
+  profile_is_admin BOOLEAN;
+  profile_user_status TEXT;
+  profile_first_name TEXT;
+  profile_last_name TEXT;
+BEGIN
+  -- Extract metadata passed during invitation
+  metadata := NEW.raw_app_meta_data; -- Data from inviteUserByEmail is in raw_app_meta_data
+
+  profile_company_id := (metadata ->> 'company_id')::UUID;
+  profile_user_role := metadata ->> 'user_role';
+  profile_is_admin := COALESCE((metadata ->> 'is_admin')::BOOLEAN, FALSE); -- Default to FALSE if not present
+  profile_user_status := COALESCE(metadata ->> 'user_status', 'Active'); -- Default to 'Active' as user has accepted invite
+  profile_first_name := metadata ->> 'first_name';
+  profile_last_name := metadata ->> 'last_name';
+
+  -- Create a new profile entry
+  INSERT INTO public.profiles (
+    id,
+    email,
+    first_name,
+    last_name,
+    user_role,
+    company_id,
+    is_admin,
+    user_status,
+    preferred_ui_language -- consider adding this to invite metadata or using a default
+  )
+  VALUES (
+    NEW.id,
+    NEW.email,
+    profile_first_name,
+    profile_last_name,
+    profile_user_role,
+    profile_company_id,
+    profile_is_admin,
+    profile_user_status,
+    COALESCE((metadata ->> 'preferred_ui_language')::TEXT, 'en') -- Default to 'en'
+  );
+
+  -- Additionally, you might want to update the app_metadata on the auth.user object
+  -- if you want to store some of this information directly on the auth user as well,
+  -- for example, for RLS policies that directly use jwt app_metadata.
+  -- This is optional and depends on your RLS strategy.
+  -- Example:
+  -- UPDATE auth.users
+  -- SET raw_app_meta_data = raw_app_meta_data || jsonb_build_object('company_id', profile_company_id, 'user_role', profile_user_role, 'is_admin', profile_is_admin)
+  -- WHERE id = NEW.id;
+  -- For simplicity, this example focuses on populating public.profiles.
+
+  RETURN NEW;
+END;
+$$;
+
+-- Drop existing trigger on auth.users if it was named differently or for cleanup
+-- DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users; -- Be cautious if you have other triggers
+
+-- Create the trigger to call this function after a new user is inserted in auth.users
+CREATE TRIGGER on_auth_user_invited_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_invited_user();
+
+COMMENT ON FUNCTION public.handle_new_invited_user() IS
+'Handles creation of a public.profiles entry for a new user created via invitation, using metadata from inviteUserByEmail.';
+COMMENT ON TRIGGER on_auth_user_invited_created ON auth.users IS
+'After a new user is created in auth.users (e.g. after accepting an invitation), create their corresponding profile in public.profiles.';
+
+-- Advise user:
+-- IMPORTANT: Review your existing trigger 'on_new_user_profile_created' on 'public.profiles'.
+-- It appears to be designed for a different signup flow or profile creation process.
+-- If users are now primarily added via invitation or a standard Supabase signup that creates an auth.users entry first,
+-- the old trigger 'on_new_user_profile_created' might be redundant or could cause conflicts
+-- (e.g., trying to update a profile that this new trigger already created).
+-- You may need to modify or remove it depending on your overall user management strategy.
+-- The trigger 'handle_new_user_profile_setup' which is called by 'on_new_user_profile_created'
+-- might still be relevant if you have other flows that insert directly into public.profiles first,
+-- or if users can sign up without an invitation and then have their profile updated.
+-- This new 'on_auth_user_invited_created' trigger is specifically for the invite flow.


### PR DESCRIPTION
This commit introduces the functionality for an admin to add a new staff member by sending an email invitation via Supabase Auth.

Key components:
1.  Client-Side (`js/staff-management.js`):
    - The 'Add Staff' modal form submission in `handleAddStaffFormSubmit` now calls a Supabase Edge Function (`invite-staff-member`) instead of inserting directly into the `profiles` table.
    - Success and error messages updated for the invitation context.

2.  Edge Function (`supabase/functions/invite-staff-member/index.ts`):
    - Created a new Edge Function that: - Receives staff details (email, first name, last name, role). - Verifies the invoking user is an admin and retrieves their `company_id`. - Uses `supabase.auth.admin.inviteUserByEmail()` to send an invitation, passing staff details and `company_id` as metadata.
    - Includes CORS handling and robust error reporting.

3.  Database Trigger (`supabase/migrations/..._create_auth_users_trigger.sql`):
    - Created a new SQL function `public.handle_new_invited_user()` and a trigger `on_auth_user_invited_created` on the `auth.users` table.
    - This trigger fires after a new user (e.g., an invited staff member) is inserted into `auth.users`.
    - It populates the `public.profiles` table with the details (name, email, role, company_id, is_admin=false, status='Active') extracted from the invitation metadata (`NEW.raw_app_meta_data`) and the new `auth.users` record.
    - Includes an advisory note about reviewing existing triggers on `public.profiles` to prevent conflicts.

This set of changes enables a more robust and secure way to add new staff members, leveraging Supabase's invitation and authentication mechanisms.