### PR TITLE
Fix: Correct 'Add Staff' modal button and update text to 'Send Invite'

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -299,7 +299,7 @@
     "modals": {
       "buttons": {
         "cancel": "Abbrechen",
-        "save": "Mitarbeiter speichern",
+        "save": "Einladung senden",
         "close": "Schließen",
         "saveChanges": "Änderungen speichern"
       },

--- a/locales/en.json
+++ b/locales/en.json
@@ -299,7 +299,7 @@
     "modals": {
       "buttons": {
         "cancel": "Cancel",
-        "save": "Save Staff Member",
+        "save": "Send Invite",
         "close": "Close",
         "saveChanges": "Save Changes"
       },

--- a/pages/staff.html
+++ b/pages/staff.html
@@ -116,7 +116,7 @@
               </div>
               <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" data-i18n="staffPage.modals.buttons.cancel">Cancel</button>
-                <button type="button" class="btn btn-primary" id="saveNewStaffBtn" data-i18n="staffPage.modals.buttons.save">Save Staff Member</button>
+                <button type="submit" class="btn btn-primary" id="saveNewStaffBtn" data-i18n="staffPage.modals.buttons.save">Send Invite</button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
This commit addresses two items for the 'Add Staff' modal on the staff page:

1.  Fixes Form Submission:
    - The button `saveNewStaffBtn` (previously 'Save Staff Member') in `pages/staff.html` has been changed from `type="button"` to `type="submit"`. This ensures that clicking the button correctly submits the `addStaffForm`, allowing the `handleAddStaffFormSubmit` JavaScript function to be triggered.

2.  Updates Button Text to 'Send Invite':
    - The fallback text for `saveNewStaffBtn` in `pages/staff.html` has been changed to "Send Invite".
    - The English translation for the i18n key `staffPage.modals.buttons.save` in `locales/en.json` has been updated from "Save Staff Member" to "Send Invite".
    - The German translation for the same key in `locales/de.json` has been updated from "Mitarbeiter speichern" to "Einladung senden".

These changes ensure the modal's primary action button works correctly and its text accurately reflects the staff invitation process.