### PR TITLE
Style: Align set-password.html form with sign-in/up page styling

### DIFF
--- a/pages/set-password.html
+++ b/pages/set-password.html
@@ -46,30 +46,24 @@
             <!-- <img src="../assets/images/your-logo.svg" alt="Property Hub Logo"> -->
             <div class="app-title-text" data-i18n="appTitle">Property Hub</div>
         </div>
-        <h2 class="text-center mb-4" data-i18n="setPasswordPage.title">Set Your Password</h2>
+        <h2 class="h3 mb-3 fw-semibold text-center" data-i18n="setPasswordPage.title">Set Your Password</h2>
         <p class="text-center text-muted mb-4" data-i18n="setPasswordPage.instructions">
             Welcome! Please choose a strong password to secure your account.
         </p>
         <form id="setPasswordForm">
-            <div class="mb-3">
-                <label for="newPassword" class="form-label" data-i18n="setPasswordPage.form.newPasswordLabel">New Password</label>
-                <div class="input-group">
-                    <span class="input-group-text"><i class="bi bi-lock-fill"></i></span>
-                    <input type="password" class="form-control" id="newPassword" required autocomplete="new-password">
-                </div>
-                <small id="passwordHelp" class="form-text text-muted" data-i18n="setPasswordPage.form.passwordHelp">
-                    Password must be at least 6 characters long.
-                </small>
+            <div class="form-floating mb-3">
+                <input type="password" class="form-control" id="newPassword" placeholder="New Password" required autocomplete="new-password">
+                <label for="newPassword" data-i18n="setPasswordPage.form.newPasswordLabel">New Password</label>
             </div>
-            <div class="mb-3">
-                <label for="confirmPassword" class="form-label" data-i18n="setPasswordPage.form.confirmPasswordLabel">Confirm New Password</label>
-                <div class="input-group">
-                    <span class="input-group-text"><i class="bi bi-lock-fill"></i></span>
-                    <input type="password" class="form-control" id="confirmPassword" required autocomplete="new-password">
-                </div>
+            <small id="passwordHelp" class="form-text text-muted mb-3" data-i18n="setPasswordPage.form.passwordHelp">
+                Password must be at least 6 characters long.
+            </small>
+            <div class="form-floating mb-3">
+                <input type="password" class="form-control" id="confirmPassword" placeholder="Confirm New Password" required autocomplete="new-password">
+                <label for="confirmPassword" data-i18n="setPasswordPage.form.confirmPasswordLabel">Confirm New Password</label>
             </div>
             <div id="setPasswordMessage" class="mt-3 mb-3"></div> <!-- For displaying success/error messages -->
-            <button type="submit" class="btn btn-primary w-100" id="setPasswordBtn" data-i18n="setPasswordPage.form.submitButton">Set Password & Sign In</button>
+            <button type="submit" class="btn btn-primary w-100 py-2" id="setPasswordBtn" data-i18n="setPasswordPage.form.submitButton">Set Password & Sign In</button>
         </form>
         <div class="text-center mt-3">
             <a href="../index.html" data-i18n="setPasswordPage.backToSignIn">Back to Sign In</a>


### PR DESCRIPTION
This commit updates the styling of `pages/set-password.html` to be more visually consistent with your existing sign-in/sign-up forms in `index.html`.

Key changes:
- I implemented Bootstrap 5 floating labels for the "New Password" and "Confirm New Password" input fields.
- I removed the input group icons previously used with these fields to maintain consistency with other floating label inputs in your app.
- I adjusted the CSS class for the page title (`<h2>`) to match the styling of titles on the sign-in/sign-up page (e.g., `h3 mb-3 fw-semibold text-center`).
- I added the `py-2` class to the submit button for consistent padding.

These changes enhance the visual consistency of your user authentication pages.