### PR TITLE
Alright, I've made some changes to address the task visibility and pr…

### DIFF
--- a/js/tasks-display.js
+++ b/js/tasks-display.js
@@ -232,9 +232,9 @@ async function fetchTasksAndRelatedData() {
         task_status,
         task_due_date,
         property_id,
-        staff_id,
-        properties ( property_name ),
-        profiles ( first_name, last_name )
+        // staff_id, // Removed
+        properties ( property_name )
+        // profiles ( first_name, last_name ) // Removed
       `);
 
     if (error) {
@@ -254,7 +254,7 @@ async function fetchTasksAndRelatedData() {
       id: task.task_id,
       title: task.task_title,
       property: task.properties ? task.properties.property_name : 'N/A',
-      assignedTo: task.profiles ? `${task.profiles.first_name || ''} ${task.profiles.last_name || ''}`.trim() : 'N/A',
+      assignedTo: 'N/A', // Placeholder for now
       status: task.task_status, // Keep original status for logic
       dueDate: task.task_due_date
     }));

--- a/supabase/migrations/20240514103300_add_rls_for_task_properties.sql
+++ b/supabase/migrations/20240514103300_add_rls_for_task_properties.sql
@@ -1,0 +1,49 @@
+-- supabase/migrations/YYYYMMDDHHMMSS_add_rls_for_task_properties.sql
+
+-- Ensure RLS is enabled on the properties table.
+-- If it's not, the user needs to enable it in Supabase Dashboard:
+-- Authentication -> Policies -> properties table -> Enable RLS.
+-- This script assumes RLS is already enabled, as other policies exist.
+
+-- RLS Policy: Allow users to read property details if they are assigned to a task on that property.
+CREATE POLICY "Allow assigned users to read property details for their tasks"
+ON public.properties
+FOR SELECT
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.tasks t -- Assuming your tasks table is named 'tasks'
+    WHERE
+      t.property_id = properties.id AND -- Links the property to a task on this property
+      t.staff_id = auth.uid()        -- Links that task to the currently authenticated user
+      -- Ensure 't.property_id' correctly references 'properties.id'
+      -- Ensure 't.staff_id' correctly references the user ID (auth.uid())
+  )
+);
+
+COMMENT ON POLICY "Allow assigned users to read property details for their tasks" ON public.properties IS
+'Allows authenticated users to select property details if they are assigned to a task associated with that property.';
+
+-- IMPORTANT NOTES FOR USER (to be communicated separately, but good to have in mind):
+-- 1. Table and Column Names:
+--    - This policy assumes your tasks table is named `public.tasks`.
+--    - It assumes `public.tasks` has a column `property_id` that is a foreign key to `public.properties.id`.
+--    - It assumes `public.tasks` has a column `staff_id` that stores the UUID of the assigned user (matching `auth.uid()`).
+--    If your table or column names are different, you MUST adjust this policy definition accordingly.
+--
+-- 2. Existing Policies:
+--    This policy is additive. If other SELECT policies exist on `public.properties` (like the admin/owner one),
+--    a user only needs to satisfy ONE of them to gain access. For example, an admin will still see all properties
+--    via their existing "Allow read access to properties of owned companies" policy, and also any properties
+--    they happen to be assigned tasks for via this new policy.
+--
+-- 3. Performance:
+--    The `EXISTS` subquery is generally efficient, especially if there are indexes on
+--    `tasks.property_id` and `tasks.staff_id`.
+--
+-- 4. Testing:
+--    After applying, test thoroughly by logging in as a regular staff user assigned to a task.
+--    They should now see the property name for that task.
+--    Also test that they CANNOT see property names for tasks they are NOT assigned to,
+--    and cannot directly query properties they have no task linkage to (unless another RLS policy grants it).

--- a/supabase/migrations/20240514103400_rls_tasks_select_by_assignment.sql
+++ b/supabase/migrations/20240514103400_rls_tasks_select_by_assignment.sql
@@ -1,0 +1,41 @@
+-- supabase/migrations/YYYYMMDDHHMMSS_rls_tasks_select_by_assignment.sql
+
+-- Ensure RLS is enabled on the tasks table.
+-- (User previously shared RLS policies for tasks, so it should be enabled.)
+
+-- It's recommended to first DROP or ALTER the existing policy that grants users SELECT access based on tasks.staff_id
+-- Example (user needs to verify the exact name of their old policy):
+-- DROP POLICY IF EXISTS "Allow assigned users to read task" ON public.tasks;
+-- Or, if they want to keep it for some reason and this new one is additive (less likely for this case):
+-- Make sure the old policy is not overly permissive in a way that conflicts.
+
+-- RLS Policy: Allow users to read tasks if they are assigned via the task_assignments table.
+CREATE POLICY "Allow users to view tasks assigned via task_assignments"
+ON public.tasks
+FOR SELECT
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.task_assignments ta
+    WHERE
+      ta.task_id = tasks.task_id AND -- Corrected: tasks.task_id (assuming tasks PK is 'task_id')
+      ta.user_id = auth.uid()   -- Links the assignment to the currently authenticated user
+  )
+);
+
+COMMENT ON POLICY "Allow users to view tasks assigned via task_assignments" ON public.tasks IS
+'Allows authenticated users to select tasks if they have an assignment record in the task_assignments table linking them to the task.';
+
+-- IMPORTANT NOTES FOR USER (to be communicated separately):
+-- 1. Table and Column Names:
+--    - This policy assumes your tasks table primary key is `task_id`.
+--    - It assumes `public.task_assignments` has `task_id` (referencing `tasks.task_id`) and `user_id` (referencing `auth.uid()`).
+--    If your column names are different, you MUST adjust this policy definition.
+--
+-- 2. Replace Existing User SELECT Policy:
+--    This policy is intended to be the primary way regular users see their tasks.
+--    You likely have an existing policy (e.g., named "Allow assigned users to read task")
+--    that uses `tasks.staff_id`. You should DROP or ALTER that old policy to avoid conflicts
+--    or incorrect permissions, making this the new rule for assigned task visibility for users.
+--    Admin/owner policies for viewing all tasks in a company would remain separate and still function.

--- a/supabase/migrations/20240514103500_rls_properties_select_for_task_assignees.sql
+++ b/supabase/migrations/20240514103500_rls_properties_select_for_task_assignees.sql
@@ -1,0 +1,46 @@
+-- supabase/migrations/YYYYMMDDHHMMSS_rls_properties_select_for_task_assignees.sql
+
+-- Ensure RLS is enabled on the properties table.
+
+-- It's CRITICAL to DROP the temporary permissive policy first if it's still active:
+-- DROP POLICY IF EXISTS "TEMP - Allow all authenticated to read properties" ON public.properties;
+-- Also, the previously problematic policy "Allow assigned users to read property details for their tasks"
+-- (the one that used tasks.staff_id) should have been dropped. If not, drop it too:
+-- DROP POLICY IF EXISTS "Allow assigned users to read property details for their tasks" ON public.properties;
+
+-- RLS Policy: Allow users to read property details if they are assigned (via task_assignments)
+--             to a task that is on that property.
+CREATE POLICY "Allow task assignees to read linked property details"
+ON public.properties
+FOR SELECT
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.tasks t
+    JOIN public.task_assignments ta ON t.task_id = ta.task_id -- Corrected: t.task_id
+    WHERE
+      t.property_id = properties.id AND -- Links the task (which is linked to the assignment) to the property
+      ta.user_id = auth.uid()         -- Links that assignment to the currently authenticated user
+      -- Ensure 't.property_id' correctly references 'properties.id'
+      -- Ensure 't.task_id' is the PK of tasks and 'ta.task_id' references it
+      -- Ensure 'ta.user_id' correctly references the user ID (auth.uid())
+  )
+);
+
+COMMENT ON POLICY "Allow task assignees to read linked property details" ON public.properties IS
+'Allows authenticated users to select property details if they are assigned (via task_assignments table) to a task associated with that property.';
+
+-- IMPORTANT NOTES FOR USER (to be communicated separately):
+-- 1. Table and Column Names:
+--    - Assumes tasks table is `public.tasks` with PK `task_id` and FK `property_id`.
+--    - Assumes assignments table is `public.task_assignments` with `task_id` (referencing `tasks.task_id`) and `user_id` (referencing `auth.uid()`).
+--    If your names differ, you MUST adjust this policy.
+--
+-- 2. Interaction with Other Policies:
+--    This is additive. Admins will likely have broader access via other policies.
+--    This policy specifically grants access to properties linked through a user's task assignments.
+--
+-- 3. Dropping Old/Temporary Policies:
+--    Crucially, ensure the "TEMP - Allow all authenticated to read properties" policy is dropped before or when applying this.
+--    Also, ensure any previous versions of "Allow assigned users to read property details for their tasks" are dropped.


### PR DESCRIPTION
…operty name display on the tasks page. This was necessary after `tasks.staff_id` was removed and the `task_assignments` table was introduced.

Here's a breakdown of what I did:

1.  **JavaScript (`js/tasks-display.js`):**
    *   I updated `fetchTasksAndRelatedData` to stop trying to select the deleted `staff_id` column from the `tasks` table.
    *   I removed the direct join to `profiles` that was based on `tasks.staff_id`.
    *   For now, the "Assigned To" field in the UI will display "N/A". I'll need to make further updates to fetch assignees using `task_assignments`.
    *   These adjustments should fix the errors that were preventing any tasks from showing up.

2.  **RLS Policies (Conceptual - you applied these manually, and I've updated the corresponding files):**
    *   The RLS policy on `public.tasks` for your SELECT operations (`Allow users to view tasks assigned via task_assignments`) now correctly uses `task_assignments.task_id = tasks.task_id`. (This is reflected in `supabase/migrations/20240514103400_...sql`)
    *   The RLS policy on `public.properties` for your SELECT operations (`Allow task assignees to read linked property details`) now correctly joins `tasks` and `task_assignments` using `t.task_id = ta.task_id`. (This is reflected in `supabase/migrations/20240514103500_...sql`)

My goal with these changes is to make sure all users can see their tasks again and that property names are displayed correctly for tasks assigned to non-admin users, all based on the `task_assignments` table.