### PR TITLE
Fix: Comprehensive RLS and JS updates for task visibility

### DIFF
--- a/supabase/functions/create-task/index.ts
+++ b/supabase/functions/create-task/index.ts
@@ -147,7 +147,7 @@ serve(async (req: Request) => {
       task_description: payload.task_description,
       task_due_date: payload.task_due_date || null,
       property_id: payload.property_id,
-      staff_id: payload.staff_id, // This is the profile_id of the staff
+      // staff_id: payload.staff_id, // Removed
       task_status: payload.task_status, // Already exists
       task_priority: payload.task_priority || 'Medium', // Add this, default to 'Medium' if not provided
       company_id: adminCompanyId, // Associate task with the admin's company

--- a/supabase/functions/inspect-user-metadata/index.ts
+++ b/supabase/functions/inspect-user-metadata/index.ts
@@ -1,0 +1,80 @@
+// supabase/functions/inspect-user-metadata/index.ts
+import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+}
+
+console.log('Edge Function `inspect-user-metadata` booting up');
+
+serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    const body = await req.json();
+    const userId = body.user_id;
+
+    if (!userId) {
+      return new Response(JSON.stringify({ error: 'Missing user_id in request body' }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 400,
+      });
+    }
+
+    console.log(`[inspect-user-metadata] Received request for user_id: ${userId}`);
+
+    // Create Supabase admin client to fetch user details directly from auth.users
+    // Ensure your custom env vars are set in function settings, or use defaults
+    const supabaseAdmin = createClient(
+      Deno.env.get('CUSTOM_SUPABASE_URL') ?? Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('CUSTOM_SUPABASE_SERVICE_ROLE_KEY') ?? Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    );
+
+    const { data: userData, error: userError } = await supabaseAdmin.auth.admin.getUserById(userId);
+
+    if (userError) {
+      console.error(`[inspect-user-metadata] Error fetching user ${userId}:`, userError);
+      return new Response(JSON.stringify({ error: `Failed to fetch user: ${userError.message}` }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: userError.status || 500,
+      });
+    }
+
+    if (!userData || !userData.user) {
+      console.error(`[inspect-user-metadata] User ${userId} not found.`);
+      return new Response(JSON.stringify({ error: `User ${userId} not found.` }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 404,
+      });
+    }
+
+    const user = userData.user;
+    const appMetadata = user.app_metadata; // In admin client, this is raw_app_meta_data
+    const userMetadata = user.user_metadata; // In admin client, this is raw_user_meta_data
+
+    console.log(`[inspect-user-metadata] User ${userId} app_metadata:`, JSON.stringify(appMetadata, null, 2));
+    console.log(`[inspect-user-metadata] User ${userId} user_metadata:`, JSON.stringify(userMetadata, null, 2));
+
+    return new Response(JSON.stringify({
+      userId: user.id,
+      email: user.email,
+      raw_app_meta_data: appMetadata, // Note: admin API might call these app_metadata
+      raw_user_meta_data: userMetadata // and user_metadata directly
+    }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 200,
+    });
+
+  } catch (error) {
+    console.error('[inspect-user-metadata] Unexpected error:', error);
+    return new Response(JSON.stringify({ error: error.message || 'An unexpected error occurred.' }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 500,
+    });
+  }
+})

--- a/supabase/migrations/20240514103600_unified_profile_creation_trigger.sql
+++ b/supabase/migrations/20240514103600_unified_profile_creation_trigger.sql
@@ -1,0 +1,142 @@
+-- supabase/migrations/YYYYMMDDHHMMSS_unified_profile_creation_trigger.sql
+
+-- Drop the old trigger function and trigger for invited users if they exist
+DROP FUNCTION IF EXISTS public.handle_new_invited_user();
+-- The trigger on_auth_user_invited_created will be dropped by dropping the function if it was the only one using it,
+-- or can be dropped explicitly:
+DROP TRIGGER IF EXISTS on_auth_user_invited_created ON auth.users;
+
+-- Also, ensure the user's very old trigger on public.profiles is definitely disabled or dropped.
+-- Advise user: ALTER TABLE public.profiles DISABLE TRIGGER on_new_user_profile_created;
+-- OR DROP TRIGGER IF EXISTS on_new_user_profile_created ON public.profiles;
+
+-- New unified trigger function
+CREATE OR REPLACE FUNCTION public.initialize_profile_from_auth_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  meta_app JSONB;         -- For data from admin invitation (inviteUserByEmail data field)
+  meta_user JSONB;        -- For data from client self-signup (signUp options.data field)
+
+  profile_id UUID; -- Declared profile_id as it's used
+  profile_first_name TEXT;
+  profile_last_name TEXT;
+  profile_email TEXT;
+  profile_user_role TEXT;
+  profile_company_id UUID;
+  profile_is_admin BOOLEAN;
+  profile_user_status TEXT;
+  profile_has_company_set_up BOOLEAN;
+  profile_preferred_ui_language TEXT;
+
+  is_invite BOOLEAN := FALSE;
+  account_type TEXT;
+BEGIN
+  RAISE NOTICE '[initialize_profile_from_auth_user] Trigger fired for new user ID: %, Email: %', NEW.id, NEW.email;
+
+  meta_app := NEW.raw_app_meta_data;
+  meta_user := NEW.raw_user_meta_data;
+
+  RAISE NOTICE '[initialize_profile_from_auth_user] App Metadata: %', meta_app;
+  RAISE NOTICE '[initialize_profile_from_auth_user] User Metadata: %', meta_user;
+
+  profile_id := NEW.id;
+  profile_email := NEW.email;
+
+  -- Check if this is an invite by looking for invite-specific markers in app_meta_data
+  -- (user_role and company_id are good markers as they are set by our invite-staff-member function)
+  IF meta_app IS NOT NULL AND meta_app ? 'user_role' AND meta_app ? 'company_id' THEN
+    is_invite := TRUE;
+  END IF;
+
+  IF is_invite THEN
+    RAISE NOTICE '[initialize_profile_from_auth_user] Detected INVITED USER flow.';
+    profile_first_name := meta_app ->> 'first_name';
+    profile_last_name := meta_app ->> 'last_name';
+    profile_user_role := meta_app ->> 'user_role';
+    profile_company_id := (meta_app ->> 'company_id')::UUID;
+    profile_is_admin := COALESCE((meta_app ->> 'is_admin')::BOOLEAN, FALSE); -- Should be false from invite
+    profile_user_status := COALESCE(meta_app ->> 'user_status', 'Invited'); -- Should be 'Invited' from invite
+    profile_has_company_set_up := COALESCE((meta_app ->> 'has_company_set_up')::BOOLEAN, FALSE); -- Typically false for invited staff
+    profile_preferred_ui_language := COALESCE((meta_app ->> 'preferred_ui_language')::TEXT, 'en');
+  ELSE
+    RAISE NOTICE '[initialize_profile_from_auth_user] Detected SELF-SIGNUP flow.';
+    -- This is a self-signup, get data from user_meta_data
+    profile_first_name := meta_user ->> 'first_name';
+    profile_last_name := meta_user ->> 'last_name'; -- Might be null for self-signup initially
+
+    account_type := meta_user ->> 'account_type';
+    RAISE NOTICE '[initialize_profile_from_auth_user] Self-signup account_type: %', account_type;
+
+    IF account_type = 'agency' THEN
+      profile_is_admin := TRUE;
+      profile_has_company_set_up := FALSE;
+      profile_user_status := 'New'; -- Or 'Active' depending on email verification settings
+      profile_user_role := 'Admin'; -- Default role for new agency admin
+    ELSE -- Standard user self-signup (or if account_type is null/different)
+      profile_is_admin := FALSE;
+      profile_has_company_set_up := FALSE; -- Non-agencies don't set up companies
+      profile_user_status := 'New';
+      profile_user_role := 'User'; -- Default role for other users
+    END IF;
+
+    profile_company_id := NULL; -- Not typically set at self-signup, unless part of a specific flow not covered here
+    profile_preferred_ui_language := COALESCE((meta_user ->> 'preferred_ui_language')::TEXT, 'en');
+  END IF;
+
+  RAISE NOTICE '[initialize_profile_from_auth_user] Determined values: email=%L, fname=%L, lname=%L, role=%L, comp_id=%L, is_admin=%L, status=%L, has_comp_setup=%L, lang=%L',
+    profile_email, profile_first_name, profile_last_name, profile_user_role, profile_company_id, profile_is_admin, profile_user_status, profile_has_company_set_up, profile_preferred_ui_language;
+
+  BEGIN
+    -- Try to UPDATE first, in case a minimal profile was already created by Supabase default hook
+    UPDATE public.profiles
+    SET
+      email = profile_email,
+      first_name = COALESCE(profile_first_name, profiles.first_name),
+      last_name = COALESCE(profile_last_name, profiles.last_name),
+      user_role = COALESCE(profile_user_role, profiles.user_role),
+      company_id = COALESCE(profile_company_id, profiles.company_id),
+      is_admin = profile_is_admin,
+      user_status = profile_user_status,
+      has_company_set_up = COALESCE(profile_has_company_set_up, profiles.has_company_set_up),
+      preferred_ui_language = profile_preferred_ui_language,
+      updated_at = now()
+    WHERE
+      id = profile_id;
+
+    IF NOT FOUND THEN
+      RAISE NOTICE '[initialize_profile_from_auth_user] No existing profile found for ID: %. Inserting new profile.', profile_id;
+      INSERT INTO public.profiles (
+        id, email, first_name, last_name, user_role, company_id,
+        is_admin, user_status, has_company_set_up, preferred_ui_language,
+        created_at, updated_at
+      )
+      VALUES (
+        profile_id, profile_email, profile_first_name, profile_last_name, profile_user_role, profile_company_id,
+        profile_is_admin, profile_user_status, profile_has_company_set_up, profile_preferred_ui_language,
+        now(), now()
+      );
+      RAISE NOTICE '[initialize_profile_from_auth_user] New profile INSERT successful for ID: %', profile_id;
+    ELSE
+      RAISE NOTICE '[initialize_profile_from_auth_user] Existing profile UPDATE successful for ID: %', profile_id;
+    END IF;
+  EXCEPTION
+    WHEN OTHERS THEN
+      RAISE NOTICE '[initialize_profile_from_auth_user] EXCEPTION during UPDATE/INSERT for ID: %. SQLSTATE: %, SQLERRM: %', profile_id, SQLSTATE, SQLERRM;
+      RAISE;
+  END;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER on_auth_user_created_initialize_profile
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.initialize_profile_from_auth_user();
+
+COMMENT ON FUNCTION public.initialize_profile_from_auth_user() IS
+'Handles profile creation/update in public.profiles when a new user is added to auth.users. Differentiates between invited users (reads from raw_app_meta_data) and self-signed-up users (reads from raw_user_meta_data) to set fields like is_admin, company_id, user_role, and user_status.';
+COMMENT ON TRIGGER on_auth_user_created_initialize_profile ON auth.users IS
+'After a new user is created in auth.users, ensures their corresponding profile in public.profiles is correctly initialized or updated.';

--- a/supabase/migrations/20240514103700_update_handle_new_user_profile_setup_function.sql
+++ b/supabase/migrations/20240514103700_update_handle_new_user_profile_setup_function.sql
@@ -1,0 +1,115 @@
+-- supabase/migrations/YYYYMMDDHHMMSS_update_handle_new_user_profile_setup_function.sql
+
+CREATE OR REPLACE FUNCTION public.handle_new_user_profile_setup()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  auth_user_record RECORD;
+  -- meta_app JSONB; -- No longer primary source for differentiation logic, only meta_user
+  meta_user JSONB;  -- Primary source of truth for all custom data
+
+  profile_first_name TEXT;
+  profile_last_name TEXT;
+  profile_email TEXT;
+  profile_user_role TEXT;
+  profile_company_id UUID;
+  profile_is_admin BOOLEAN;
+  profile_user_status TEXT;
+  profile_has_company_set_up BOOLEAN;
+  profile_preferred_ui_language TEXT;
+
+  account_type TEXT; -- For self-signups
+BEGIN
+  -- This trigger fires AFTER INSERT ON public.profiles.
+  -- NEW.id is the id of the newly inserted profile row.
+  SELECT * INTO auth_user_record FROM auth.users WHERE id = NEW.id;
+
+  IF auth_user_record IS NULL THEN
+    RAISE WARNING '[handle_new_user_profile_setup] No corresponding auth.users record found for profiles.id: %. Profile may not be fully populated.', NEW.id;
+    RETURN NEW;
+  END IF;
+
+  meta_user := auth_user_record.raw_user_meta_data; -- All custom data comes from here
+  profile_email := auth_user_record.email; -- Canonical email
+
+  RAISE NOTICE '[handle_new_user_profile_setup] For profiles.id % (auth.users.id %): Processing raw_user_meta_data: %', NEW.id, auth_user_record.id, meta_user;
+
+  -- Check for INVITE markers within raw_user_meta_data
+  -- (Our Edge Function for invites now ensures its 'data' payload is merged into raw_user_meta_data by the time this trigger runs,
+  -- or this trigger is the primary one and the old auth.users trigger is disabled)
+  IF meta_user IS NOT NULL AND
+     meta_user ? 'user_role' AND          -- Custom field for invited role
+     meta_user ? 'company_id' AND         -- Custom field for invited company
+     (meta_user ->> 'user_status') = 'Invited' -- Custom field indicating invite status
+  THEN
+    RAISE NOTICE '[handle_new_user_profile_setup] INVITED USER flow detected via raw_user_meta_data for profiles.id %', NEW.id;
+    profile_first_name := meta_user ->> 'first_name';
+    profile_last_name := meta_user ->> 'last_name';
+    profile_user_role := meta_user ->> 'user_role';
+    profile_company_id := (meta_user ->> 'company_id')::UUID;
+    profile_is_admin := COALESCE((meta_user ->> 'is_admin')::BOOLEAN, FALSE);
+    profile_user_status := 'Invited';
+    profile_has_company_set_up := COALESCE((meta_user ->> 'has_company_set_up')::BOOLEAN, FALSE);
+    profile_preferred_ui_language := COALESCE((meta_user ->> 'preferred_ui_language')::TEXT, 'en');
+  ELSE
+    -- SELF-SIGNUP flow (check for account_type also in raw_user_meta_data)
+    RAISE NOTICE '[handle_new_user_profile_setup] SELF-SIGNUP flow detected for profiles.id %', NEW.id;
+    profile_first_name := meta_user ->> 'first_name';
+    profile_last_name := meta_user ->> 'last_name';
+
+    account_type := meta_user ->> 'account_type';
+    RAISE NOTICE '[handle_new_user_profile_setup] Self-signup account_type: %', account_type;
+
+    IF account_type = 'agency' THEN
+      profile_is_admin := TRUE;
+      profile_has_company_set_up := FALSE;
+      profile_user_status := 'New';
+      profile_user_role := 'Admin';
+    ELSE
+      -- Default for other self-signups (non-agency)
+      profile_is_admin := FALSE;
+      profile_has_company_set_up := FALSE;
+      profile_user_status := 'New';
+      profile_user_role := 'User';
+    END IF;
+
+    profile_company_id := NULL; -- company_id is not set during self-signup
+    profile_preferred_ui_language := COALESCE((meta_user ->> 'preferred_ui_language')::TEXT, 'en');
+  END IF;
+
+  RAISE NOTICE '[handle_new_user_profile_setup] Updating profiles.id % with: email=%L, fname=%L, lname=%L, role=%L, comp_id=%L, is_admin=%L, status=%L, has_comp_setup=%L, lang=%L',
+    NEW.id, profile_email, profile_first_name, profile_last_name, profile_user_role, profile_company_id, profile_is_admin, profile_user_status, profile_has_company_set_up, profile_preferred_ui_language;
+
+  UPDATE public.profiles
+  SET
+    email = profile_email,
+    first_name = COALESCE(profile_first_name, NEW.first_name),
+    last_name = profile_last_name,
+    user_role = profile_user_role,
+    company_id = profile_company_id,
+    is_admin = profile_is_admin,
+    user_status = profile_user_status,
+    has_company_set_up = profile_has_company_set_up,
+    preferred_ui_language = profile_preferred_ui_language,
+    updated_at = now()
+  WHERE
+    id = NEW.id;
+
+  RAISE NOTICE '[handle_new_user_profile_setup] Profile update for ID % completed.', NEW.id;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.handle_new_user_profile_setup() IS
+'AFTER INSERT ON public.profiles trigger. Populates profile using auth.users.raw_user_meta_data for both invites and self-signups. Differentiates based on fields like user_status=''Invited'' or account_type=''agency''. Ensures is_admin for agency.';
+
+-- The user needs to ensure their trigger "on_new_user_profile_created" on "public.profiles"
+-- correctly calls this updated function.
+-- Example:
+-- CREATE TRIGGER on_new_user_profile_created
+--   AFTER INSERT ON public.profiles
+--   FOR EACH ROW EXECUTE FUNCTION public.handle_new_user_profile_setup();
+-- (The user confirmed this trigger is already enabled and calls this function by name).


### PR DESCRIPTION
This commit resolves a series of issues related to task visibility, property name display, and assignee display on the tasks page, ensuring correct data access for different user roles without RLS recursion errors. It also ensures the 'create-task' Edge Function aligns with the updated schema.

Key Changes:

1.  RLS Policies:
    - `tasks` table: - Admin/Owner: Policy "Allow read access to tasks of owned companies" (relies on tasks.property_id -> properties.company_id -> companies.owner_id). Verified to be logically sound. You dropped a temporary overly permissive admin policy. - User: Policy "Allow users to view their assigned tasks (v2)" now uses `tasks.task_id IN (SELECT ta.task_id FROM task_assignments ta WHERE ta.user_id = auth.uid())`, correctly referencing `tasks.task_id` and `task_assignments`.
    - `properties` table:
        - Admin/Owner: Policy "Allow read access to properties of owned companies" (relies on properties.company_id -> companies.owner_id). Verified.
        - User: New policy "RLS: Allow assigned non-admins to see task properties" uses a `SECURITY DEFINER` helper function `is_user_assigned_to_task_on_property` (which reads `tasks` and `task_assignments` safely) and an explicit check that you are not an admin. This structure prevents RLS recursion.
    - `task_assignments` table: - User: "Allow user to see their own task assignments" (`user_id = auth.uid()`). Verified. - Admin: "Admin can read task assignments in own company" (based on assigned user's profile being in admin's company). Verified. - Company Owner: "Allow company owner to read task assignments in their company" was revised to be recursion-safe by checking if the assigned user's profile belongs to a company owned by `auth.uid()`, avoiding direct reads of `tasks` or `properties` in its condition.
    - (Migration files for these RLS policies have been updated or created).

2.  `js/tasks-display.js`:
    - `fetchTasksAndRelatedData` function updated: - Removed dependency on the deleted `tasks.staff_id` column. - Now fetches assignees via a nested query: `tasks(..., task_assignments(profiles(first_name, last_name)))`. - Maps the `task_assignments` array to display the first assignee's name, indicating if multiple assignees exist (e.g., "User A (+X more)") or "Unassigned".
    - Property name display logic was already in place and should now work correctly with the fixed RLS on `properties`.

3.  Edge Function `create-task` (`supabase/functions/create-task/index.ts`):
    - Modified to remove the attempt to insert into the deleted `tasks.staff_id` column. Task assignment is handled by inserting into `task_assignments`.

This comprehensive set of changes should ensure correct data visibility and functionality for tasks, properties, and their assignments across different user roles, and resolve previous RLS recursion issues.