### PR TITLE
Fix: Correct PostgREST join syntax for task_assignments to profiles

### DIFF
--- a/js/tasks-display.js
+++ b/js/tasks-display.js
@@ -233,7 +233,7 @@ async function fetchTasksAndRelatedData() {
         task_due_date,
         property_id,
         properties ( property_name ),
-        task_assignments ( profiles ( first_name, last_name ) ) // Fetch assignees
+        task_assignments ( profiles!task_assignments_user_id_fkey ( first_name, last_name ) )
       `);
 
     if (error) {


### PR DESCRIPTION
Updates `js/tasks-display.js` to use the explicit foreign key constraint name `task_assignments_user_id_fkey` when selecting assignee profiles from `task_assignments`.

The `select` string for fetching tasks now includes: `task_assignments(profiles!task_assignments_user_id_fkey(first_name, last_name))`

This resolves the PostgREST error "Could not find a relationship between 'task_assignments' and 'profiles'" and should allow assignee names to be correctly fetched and displayed on the tasks page.