### PR TITLE
Fix: Refine PostgREST syntax for task_assignments to profiles join

### DIFF
--- a/js/tasks-display.js
+++ b/js/tasks-display.js
@@ -233,7 +233,7 @@ async function fetchTasksAndRelatedData() {
         task_due_date,
         property_id,
         properties ( property_name ),
-        task_assignments ( profiles!task_assignments_user_id_fkey ( first_name, last_name ) )
+        task_assignments ( user_id!profiles (first_name, last_name) )
       `);
 
     if (error) {


### PR DESCRIPTION
Updates `js/tasks-display.js` to use the PostgREST syntax `task_assignments ( user_id!profiles (first_name, last_name) )` for fetching assignee names.

This explicitly uses the `user_id` column from `task_assignments` as the foreign key to link to the `profiles` table. This is intended to resolve the "Could not find a relationship" error from PostgREST.