### PR TITLE
Fix: Modify staff update query to prevent PGRST116 error

### DIFF
--- a/js/staff-management.js
+++ b/js/staff-management.js
@@ -433,7 +433,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             .from('profiles')
             .update(staffUpdateData)
             .eq('id', staffId)
-            .select()
+            .select('id') // Changed from .select()
             .single();
 
         if (error) {


### PR DESCRIPTION
I changed the Supabase query in the `updateStaffMember` function in `js/staff-management.js` from `.select().single()` to `.select('id').single()`.

This is a diagnostic fix attempt to resolve the PGRST116 error ('JSON object requested, multiple (or no) rows returned') that occurred when you updated staff details. By selecting only the 'id', I can avoid potential issues with RLS preventing the full row data from being returned immediately after the update, which can trigger this error.