### PR TITLE
Feat: Enhance View Task Modal to display notes and file metadata

### DIFF
--- a/pages/tasks.html
+++ b/pages/tasks.html
@@ -112,7 +112,35 @@
         </div>
         <div class="modal-body">
           <div id="viewTaskModalBody">
-            <p>Loading task details...</p>
+            <h5 id="viewTaskTitle">Task Title</h5>
+            <p><strong>Property:</strong> <span id="viewTaskProperty">N/A</span></p>
+            <p><strong>Assigned To:</strong> <span id="viewTaskAssignees">N/A</span></p>
+            <p><strong>Status:</strong> <span id="viewTaskStatus">N/A</span></p>
+            <p><strong>Priority:</strong> <span id="viewTaskPriority">N/A</span></p>
+            <p><strong>Due Date:</strong> <span id="viewTaskDueDate">N/A</span></p>
+            <hr>
+            <p><strong>Description:</strong></p>
+            <div id="viewTaskDescription" style="white-space: pre-wrap; background-color: #f8f9fa; padding: 10px; border-radius: 5px; min-height: 50px;">N/A</div>
+            <hr>
+            <p><strong>Notes:</strong></p>
+            <div id="viewTaskNotes" style="white-space: pre-wrap; background-color: #f8f9fa; padding: 10px; border-radius: 5px; min-height: 50px;">N/A</div>
+            <hr>
+            <h6>Attached Images:</h6>
+            <ul id="viewTaskImagesList" class="list-group list-group-flush">
+              <!-- Image names will be populated here -->
+              <li class="list-group-item text-muted">No images attached.</li>
+            </ul>
+            <hr>
+            <h6>Attached Documents:</h6>
+            <ul id="viewTaskDocumentsList" class="list-group list-group-flush">
+              <!-- Document names will be populated here -->
+              <li class="list-group-item text-muted">No documents attached.</li>
+            </ul>
+            <!-- Optional: Creation/Update Dates -->
+            <div class="mt-3 text-muted small">
+              <p class="mb-0">Created: <span id="viewTaskCreatedAt">N/A</span></p>
+              <p class="mb-0">Last Updated: <span id="viewTaskUpdatedAt">N/A</span></p>
+            </div>
           </div>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
Modified `pages/tasks.html` to update the structure of the 'View Task Modal' (`viewTaskModalBody`), adding dedicated sections and elements to display comprehensive task details including task notes, and lists for attached images and documents.

Modified `js/tasks-display.js` by:
1.  Introducing a new function `fetchSingleTaskDetails(taskId)` to fetch detailed information for a single task, including its notes from the `tasks` table and related file metadata (file name, mime type, storage path) from the `task_files` table.
2.  Updating the event listener for the 'View' button on tasks. It now calls `fetchSingleTaskDetails(taskId)` and dynamically populates the enhanced modal with all fetched information, including notes and lists of file names (separated into images and documents based on mime type).

This change allows you to see more detailed information when viewing a task, laying the groundwork for future file management features. Actual file rendering/download links are not yet implemented in this commit.