### PR TITLE
Fix: Correct date field names in View Task Modal

### DIFF
--- a/js/tasks-display.js
+++ b/js/tasks-display.js
@@ -539,8 +539,8 @@ document.addEventListener('DOMContentLoaded', async () => {
           document.getElementById('viewTaskDescription').textContent = taskDetails.task_description || 'N/A';
           document.getElementById('viewTaskNotes').textContent = taskDetails.task_notes || 'No notes yet.';
 
-          document.getElementById('viewTaskCreatedAt').textContent = taskDetails.created_at ? formatDate(taskDetails.created_at) : 'N/A';
-          document.getElementById('viewTaskUpdatedAt').textContent = taskDetails.updated_at ? formatDate(taskDetails.updated_at) : 'N/A';
+          document.getElementById('viewTaskCreatedAt').textContent = taskDetails.task_created_at ? formatDate(taskDetails.task_created_at) : 'N/A';
+          document.getElementById('viewTaskUpdatedAt').textContent = taskDetails.task_updated_at ? formatDate(taskDetails.task_updated_at) : 'N/A';
 
           const imagesList = document.getElementById('viewTaskImagesList');
           imagesList.innerHTML = ''; // Clear loading/previous


### PR DESCRIPTION
Modified `js/tasks-display.js` within the View Task Modal population logic to use `taskDetails.task_created_at` and `taskDetails.task_updated_at` instead of `taskDetails.created_at` and `taskDetails.updated_at`.

This aligns with the actual column names in the `public.tasks` table and ensures that task creation and last update timestamps are correctly displayed in the modal.