### PR TITLE
Fix: Correct column names in property-details.js

### DIFF
--- a/js/property-details.js
+++ b/js/property-details.js
@@ -30,7 +30,7 @@
     // This part is mostly from the original property-details.js logic for the header
     const { data: propertyData, error: propertyError } = await supabase
         .from('properties')
-        .select('property_name,address,property_type,property_details,occupier_type,image_url')
+        .select('property_name,address,property_type,property_details,property_occupier,image_url')
         .eq('id', propertyId)
         .single();
 
@@ -42,7 +42,7 @@
         // Populate other property details if those elements exist from original script
         if(document.getElementById('propertyAddress')) document.getElementById('propertyAddress').textContent = propertyData.address;
         if(document.getElementById('propertyType')) document.getElementById('propertyType').textContent = propertyData.property_type;
-        if(document.getElementById('propertyOccupier')) document.getElementById('propertyOccupier').textContent = propertyData.occupier_type;
+        if(document.getElementById('propertyOccupier')) document.getElementById('propertyOccupier').textContent = propertyData.property_occupier;
         if(document.getElementById('propertyDetailsText')) document.getElementById('propertyDetailsText').textContent = propertyData.property_details || 'No additional details provided.';
         if(document.getElementById('propertyImage')) {
             document.getElementById('propertyImage').src = propertyData.image_url || 'https://via.placeholder.com/700x400.png?text=No+Image';


### PR DESCRIPTION
Updated `js/property-details.js` to use the correct column names `address` (instead of `property_address`) and `property_occupier` (instead of `occupier_type`) when fetching and displaying property details.

This resolves the 'column does not exist' errors previously encountered on the property details page.