### PR TITLE
Feat: Add localization keys for tasks section on property details page

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -145,6 +145,24 @@
   "tasksPage": {
     "header": "Aufgaben"
   },
+  "propertyDetailsPage": {
+    "showQrButton": "QR-Code anzeigen",
+    "tasksHeader": "[DE] Tasks for this Property",
+    "activeTasksTab": "[DE] Active Tasks",
+    "completedTasksTab": "[DE] Completed Tasks",
+    "tasksTable": {
+      "header": {
+        "title": "[DE] Task title",
+        "assignedTo": "[DE] Assigned to",
+        "status": "[DE] Status",
+        "dueDate": "[DE] Due date",
+        "actions": "[DE] Actions"
+      },
+      "noTasks": "[DE] No tasks found for this property.",
+      "noActiveTasks": "[DE] No active tasks found for this property.",
+      "noCompletedTasks": "[DE] No completed tasks found for this property."
+    }
+  },
   "notificationsPage": {
     "title": "Benachrichtigungen - Immobilien Hub",
     "header": "Benachrichtigungen",
@@ -376,9 +394,6 @@
     "updateError": "Aktualisierung des Verifizierungsstatus fehlgeschlagen. Bitte versuchen Sie es erneut.",
     "success": "Verifizierung erfolgreich! Weiterleitung...",
     "incorrectCode": "Falscher Code. Bitte versuchen Sie es erneut."
-  },
-  "propertyDetailsPage": {
-    "showQrButton": "QR-Code anzeigen"
   },
   "agencySetupPage": {
     "pageTitle": "Agentur-Setup - Property Hub",

--- a/locales/en.json
+++ b/locales/en.json
@@ -145,6 +145,24 @@
   "tasksPage": {
     "header": "Tasks"
   },
+  "propertyDetailsPage": {
+    "showQrButton": "Show QR Code",
+    "tasksHeader": "Tasks for this Property",
+    "activeTasksTab": "Active Tasks",
+    "completedTasksTab": "Completed Tasks",
+    "tasksTable": {
+      "header": {
+        "title": "Task title",
+        "assignedTo": "Assigned to",
+        "status": "Status",
+        "dueDate": "Due date",
+        "actions": "Actions"
+      },
+      "noTasks": "No tasks found for this property.",
+      "noActiveTasks": "No active tasks found for this property.",
+      "noCompletedTasks": "No completed tasks found for this property."
+    }
+  },
   "notificationsPage": {
     "title": "Notifications - Property Hub",
     "header": "Notifications",
@@ -400,9 +418,6 @@
     "updateError": "Failed to update verification status. Please try again.",
     "success": "Verification successful! Redirecting...",
     "incorrectCode": "Incorrect code. Please try again."
-  },
-  "propertyDetailsPage": {
-    "showQrButton": "Show QR Code"
   },
   "agencySetupPage": {
     "pageTitle": "Agency Company Setup - Property Hub",


### PR DESCRIPTION
I've added new i18n keys to `locales/en.json` and `locales/de.json` for the header, table column headers, and 'no tasks' messages within the tasks listing section on the `pages/property-details.html` page.

This also includes keys for the upcoming tabbed display of active and completed tasks within that section.