### PR TITLE
Remove duplicate tasks section from property details page

### DIFF
--- a/pages/property-details.html
+++ b/pages/property-details.html
@@ -87,30 +87,6 @@
         </div>
       </div>
 
-    <div class="row mt-5"> <!-- New row for the tasks section -->
-      <div class="col-12">
-        <h2>Tasks</h2>
-        <ul class="nav nav-pills mb-3" id="tasksTab" role="tablist">
-          <li class="nav-item" role="presentation">
-            <button class="nav-link active" id="active-tasks-tab" data-bs-toggle="pill" data-bs-target="#active-tasks-pane" type="button" role="tab" aria-controls="active-tasks-pane" aria-selected="true">Active</button>
-          </li>
-          <li class="nav-item" role="presentation">
-            <button class="nav-link" id="completed-tasks-tab" data-bs-toggle="pill" data-bs-target="#completed-tasks-pane" type="button" role="tab" aria-controls="completed-tasks-pane" aria-selected="false">Completed</button>
-          </li>
-        </ul>
-        <div class="tab-content" id="tasksTabContent">
-          <div class="tab-pane fade show active" id="active-tasks-pane" role="tabpanel" aria-labelledby="active-tasks-tab">
-            <!-- Active tasks will be dynamically inserted here -->
-            <p class="text-muted no-tasks-message">Loading active tasks...</p>
-          </div>
-          <div class="tab-pane fade" id="completed-tasks-pane" role="tabpanel" aria-labelledby="completed-tasks-tab">
-            <!-- Completed tasks will be dynamically inserted here -->
-            <p class="text-muted no-tasks-message">Loading completed tasks...</p>
-          </div>
-        </div>
-      </div>
-    </div>
-
     <!-- Tasks Section -->
     <div class="mt-5"> <!-- Add some top margin -->
       <h3 class="mb-3" data-i18n="propertyDetailsPage.tasksHeader">Tasks for this Property</h3>


### PR DESCRIPTION
This commit removes an unused tasks section from the `pages/property-details.html` page. The removed section included tabs for 'Active' and 'Completed' tasks but was not the primary display for tasks associated with a property. Another section further down the page correctly displays tasks in a table format, and this remains untouched.